### PR TITLE
Queue toggle and stuck in queue fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akselglyholt</groupId>
     <artifactId>velocity-limbo-handler</artifactId>
-    <version>1.1-snapshot</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>velocity-limbo-handler</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akselglyholt</groupId>
     <artifactId>velocity-limbo-handler</artifactId>
-    <version>1.0.0</version>
+    <version>1.1-snapshot</version>
     <packaging>jar</packaging>
 
     <name>velocity-limbo-handler</name>

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -175,6 +175,7 @@ public class VelocityLimboHandler {
                 nextPlayer.createConnectionRequest(previousServer).connect().whenComplete((result, throwable) -> {
                     if (result.isSuccessful()) {
                         Utility.logInformational(String.format("Successfully reconnected %s to %s.", finalNextPlayer.getUsername(), previousServer.getServerInfo().getName()));
+                        playerManager.removePlayerIssue(finalNextPlayer);
                         return;
                     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -22,6 +22,8 @@ import dev.dejvokep.boostedyaml.settings.loader.LoaderSettings;
 import dev.dejvokep.boostedyaml.settings.updater.UpdaterSettings;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,6 +37,7 @@ import java.util.logging.Logger;
 
 @Plugin(id = "velocity-limbo-handler", name = "VelocityLimboHandler", version = "1.0")
 public class VelocityLimboHandler {
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(VelocityLimboHandler.class);
     private static ProxyServer proxyServer;
     private static Logger logger;
     private static RegisteredServer limboServer;
@@ -161,25 +164,77 @@ public class VelocityLimboHandler {
                         return;
                     }
 
-                    if (throwable != null) {
-                        String lowerMessage = throwable.getMessage().toLowerCase();
+                    Utility.logInformational(String.format("Connection failed for %s to %s. Result status: %s",
+                            nextPlayer.getUsername(), previousServer.getServerInfo().getName(), result.getStatus()));
 
-                        if (lowerMessage.contains("ban")) {
+                    if (throwable != null) {
+                        log.error("Connection Message Error: " + throwable.getMessage());
+
+                        // Get the error message from throwable
+                        String errorMessage = throwable.getMessage();
+
+                        if (errorMessage == null) {
+                            errorMessage = "";
+                        }
+
+                        log.info("Disconnect reason (throwable): " + errorMessage);
+
+                        // Also check the result component if available
+                        String reasonFromComponent = "";
+                        if (result.getReasonComponent().isPresent()) {
+                            reasonFromComponent = PlainTextComponentSerializer.plainText().serialize(result.getReasonComponent().get());
+                            log.info("Disconnect reason (component): " + reasonFromComponent);
+                        }
+
+                        // Check both the throwable message and the component reason
+                        String combinedErrorMessage = (errorMessage + " " + reasonFromComponent).toLowerCase();
+
+                        if (combinedErrorMessage.contains("ban") || combinedErrorMessage.contains("banned")) {
                             nextPlayer.sendMessage(miniMessage.deserialize("<red>⛔ You are banned from that server.</red>"));
                             playerManager.removePlayer(nextPlayer);
-                            nextPlayer.disconnect(miniMessage.deserialize("<red>You're banned from that server!"));
+                            nextPlayer.disconnect(miniMessage.deserialize("<red>You're banned from that server!</red>"));
                             return;
                         }
 
-                        if (lowerMessage.contains("whitelist") || lowerMessage.contains("not whitelisted")) {
+                        if (combinedErrorMessage.contains("whitelist") || combinedErrorMessage.contains("not whitelisted")) {
                             nextPlayer.sendMessage(miniMessage.deserialize("<red>⚠ You are not whitelisted on that server.</red>"));
                             playerManager.removePlayer(nextPlayer);
-                            nextPlayer.disconnect(Component.text("You're not whitelisted to the server you're trying to connect to!"));
+                            nextPlayer.disconnect(miniMessage.deserialize("<red>You're not whitelisted on the server you're trying to connect to!</red>"));
                             return;
                         }
 
-                        //nextPlayer.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + throwable.getMessage() + "</red>"));
-                        //playerManager.removePlayer(nextPlayer);
+                        // Handle any other connection errors
+                        nextPlayer.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + (errorMessage.isEmpty() ? reasonFromComponent : errorMessage) + "</red>"));
+                        // Uncomment the next line if you want to remove players from queue on any error
+                        // playerManager.removePlayer(nextPlayer);
+                    } else {
+                        // Handle case where we have a result but no throwable
+                        Optional<Component> reasonComponent = result.getReasonComponent();
+                        if (reasonComponent.isPresent()) {
+                            String reason = PlainTextComponentSerializer.plainText().serialize(reasonComponent.get()).toLowerCase();
+                            log.info("Disconnect reason (from result): " + reason);
+
+                            if (reason.contains("whitelist") || reason.contains("not whitelisted")) {
+                                nextPlayer.sendMessage(miniMessage.deserialize("<red>⚠ You are not whitelisted on that server.</red>"));
+                                // Instead of kicking and removing the player, mark them with an issue
+                                playerManager.addPlayerWithIssue(nextPlayer, "not_whitelisted");
+                                // Remove them from the reconnection queue but keep them in limbo
+                                playerManager.removePlayer(nextPlayer);
+                                return;
+                            }
+
+                            if (reason.contains("ban") || reason.contains("banned")) {
+                                nextPlayer.sendMessage(miniMessage.deserialize("<red>⛔ You are banned from that server.</red>"));
+                                // Instead of kicking and removing the player, mark them with an issue
+                                playerManager.addPlayerWithIssue(nextPlayer, "banned");
+                                // Remove them from the reconnection queue but keep them in limbo
+                                playerManager.removePlayer(nextPlayer);
+                                return;
+                            }
+
+
+                            nextPlayer.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + reason + "</red>"));
+                        }
                     }
                 });
 
@@ -191,15 +246,23 @@ public class VelocityLimboHandler {
 
         // Schedule queue position notifier
         proxyServer.getScheduler().buildTask(this, () -> {
-            if (!queueEnabled) return;
 
-            for (Player player : playerManager.getReconnectQueue()) {
+            for (Player player : limboServer.getPlayersConnected()) {
+                // Check if player has a connection issue
+                if (playerManager.hasConnectionIssue(player)) {
+                    String issue = playerManager.getConnectionIssue(player);
 
-                if (!player.isActive()) {
-                    playerManager.removePlayer(player);
+                    if ("banned".equals(issue)) {
+                        player.sendMessage(miniMessage.deserialize("<red>⛔ You are banned from the server you were trying to connect to.</red>"));
+                    } else if ("not_whitelisted".equals(issue)) {
+                        player.sendMessage(miniMessage.deserialize("<red>⚠ You are not whitelisted on the server you were trying to connect to.</red>"));
+                    }
                     continue;
                 }
 
+                if (!queueEnabled) continue;
+
+                // Original queue position code for players without issues
                 int position = playerManager.getQueuePosition(player);
 
                 if (position == -1) continue;

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/ConnectionListener.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/ConnectionListener.java
@@ -53,5 +53,6 @@ public class ConnectionListener {
     @Subscribe
     public void onDisconnect(@NotNull DisconnectEvent event) {
         VelocityLimboHandler.getPlayerManager().removePlayer(event.getPlayer());
+        VelocityLimboHandler.getPlayerManager().removePlayerIssue(event.getPlayer());
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -6,15 +6,14 @@ import com.velocitypowered.api.proxy.server.RegisteredServer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Queue;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class PlayerManager {
     private final Map<Player, RegisteredServer> playerData;
     private final Queue<Player> reconnectQueue = new LinkedList<>();
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
+    private final Map<UUID, String> playerConnectionIssues = new ConcurrentHashMap<>();
 
     public PlayerManager() {
         this.playerData = new LinkedHashMap<>();
@@ -66,4 +65,19 @@ public class PlayerManager {
         return reconnectQueue;
     }
 
+    public void addPlayerWithIssue(Player player, String issue) {
+        playerConnectionIssues.put(player.getUniqueId(), issue);
+    }
+
+    public boolean hasConnectionIssue(Player player) {
+        return playerConnectionIssues.containsKey(player.getUniqueId());
+    }
+
+    public String getConnectionIssue(Player player) {
+        return playerConnectionIssues.get(player.getUniqueId());
+    }
+
+    public void removePlayerIssue(Player player) {
+        playerConnectionIssues.remove(player.getUniqueId());
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-file-version: 1
+file-version: 2
 
 # Server configs - These are settings you need to change!
 # The name of the limbo server in your velocity network
@@ -11,5 +11,6 @@ direct-connect-server: lobby # Default "lobby"
 task-interval: 3 # The time in seconds (Default: 3)
 
 # How often should the user be notified of their position in the queue
-queue-notify-interval: 30 # The time in seconds (Default 30)
+queue-enabled: true # Should players be reconnected through a queue (Default: true)
+queue-notify-interval: 30 # The time in seconds (Default: 30)
 

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "velocity-limbo-handler",
   "name": "Velocity Limbo Handler",
-  "version": "1.0.0",
+  "version": "1.1-snapshot",
   "authors": ["Aksel Glyholt"],
   "main": "com.akselglyholt.velocityLimboHandler.VelocityLimboHandler"
 }

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "velocity-limbo-handler",
   "name": "Velocity Limbo Handler",
-  "version": "1.1-snapshot",
+  "version": "1.1.0",
   "authors": ["Aksel Glyholt"],
   "main": "com.akselglyholt.velocityLimboHandler.VelocityLimboHandler"
 }


### PR DESCRIPTION
## Features
- Queue toggle from config using "queue-enabled: true"

## Bug Fixes
- Fixed issue where banned players were kicked from the proxy entirely
- Fixed queue system becoming blocked when a player with connection issues was at the front of the queue
- Fixed error message detection to properly identify ban and whitelist messages