### PR TITLE
Fix queue message for disabled mode

### DIFF
--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -22,10 +22,14 @@ public class PlayerManager {
 
     public void addPlayer(Player player, RegisteredServer registeredServer) {
         this.playerData.put(player, registeredServer);
-        this.reconnectQueue.add(player);
 
-        int position = getQueuePosition(player);
-        player.sendMessage(miniMessage.deserialize("<yellow>You are in the queue. Position: " + position));
+        // Only maintain a reconnect queue when queue mode is enabled
+        if (VelocityLimboHandler.isQueueEnabled()) {
+            this.reconnectQueue.add(player);
+
+            int position = getQueuePosition(player);
+            player.sendMessage(miniMessage.deserialize("<yellow>You are in the queue. Position: " + position));
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- avoid queue management when queue mode is off

## Testing
- `mvn -q -e -B package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd177fed8832e83f1509a31a76a5c