### PR TITLE
Added command blocker

### DIFF
--- a/src/main/java/com/akselglyholt/velocityLimboHandler/commands/CommandBlockRule.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/commands/CommandBlockRule.java
@@ -1,0 +1,16 @@
+package com.akselglyholt.velocityLimboHandler.commands;
+
+import com.velocitypowered.api.proxy.Player;
+
+@FunctionalInterface
+public interface CommandBlockRule {
+    boolean shouldBlock(Player player);
+
+    static CommandBlockRule onServer(String serverName) {
+        return player -> player.getCurrentServer()
+                .map(s -> s.getServerInfo().getName().equalsIgnoreCase(serverName))
+                .orElse(false);
+    }
+
+    // Add more reusable helpers later if needed
+}

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/commands/CommandBlocker.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/commands/CommandBlocker.java
@@ -1,0 +1,16 @@
+package com.akselglyholt.velocityLimboHandler.commands;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CommandBlocker {
+    private final Map<String, CommandBlockRule> commandRules = new HashMap<>();
+
+    public void blockCommand(String command, CommandBlockRule rule) {
+        commandRules.put(command.toLowerCase(), rule);
+    }
+
+    public final Map<String, CommandBlockRule> getCommandRules() {
+        return commandRules;
+    }
+}

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/CommandExecuteEventListener.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/CommandExecuteEventListener.java
@@ -1,0 +1,45 @@
+package com.akselglyholt.velocityLimboHandler.listeners;
+
+import com.akselglyholt.velocityLimboHandler.commands.CommandBlockRule;
+import com.akselglyholt.velocityLimboHandler.commands.CommandBlocker;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.command.CommandExecuteEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ServerConnection;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class CommandExecuteEventListener {
+    private final CommandBlocker commandBlocker;
+
+    public CommandExecuteEventListener(CommandBlocker commandBlocker) {
+        this.commandBlocker = commandBlocker;
+    }
+
+    @Subscribe
+    public void onCommandExecute(CommandExecuteEvent event) {
+        if (!(event.getCommandSource() instanceof Player player)) {
+            return;
+        }
+
+        Optional<ServerConnection> serverConnection = player.getCurrentServer();
+
+        if (serverConnection.isPresent()) {
+            String serverName = serverConnection.get().getServerInfo().getName();
+            String command = event.getCommand();
+            String commandName = command.split(" ")[0].toLowerCase(); // Extract command name
+
+            // Get the rule for this specific command
+            CommandBlockRule rule = commandBlocker.getCommandRules().get(commandName);
+
+            if (rule != null && rule.shouldBlock(player)) {
+                event.setResult(CommandExecuteEvent.CommandResult.denied());
+                player.sendMessage(Component.text("Commands are disabled on this server!")
+                        .color(NamedTextColor.RED));
+            }
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-file-version: 2
+file-version: 3
 
 # Server configs - These are settings you need to change!
 # The name of the limbo server in your velocity network
@@ -13,4 +13,7 @@ task-interval: 3 # The time in seconds (Default: 3)
 # How often should the user be notified of their position in the queue
 queue-enabled: true # Should players be reconnected through a queue (Default: true)
 queue-notify-interval: 30 # The time in seconds (Default: 30)
+
+# A list of disabled commands, which will not work inside the Limbo server. Recommended commands are ones that the player can use to transfer server, like /server or /hub
+disabled-commands: ["server", "lobby", "hub"]
 


### PR DESCRIPTION
Added a command blocking system for the limbo server, to prevent players from just using /server to skip queue

New config section, to add disabled commands
```yml
# A list of disabled commands, which will not work inside the Limbo server. Recommended commands are ones that the player can use to transfer server, like /server or /hub
disabled-commands: ["server", "lobby", "hub"]
```