### PR TITLE
Added bypass check for maintenance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akselglyholt</groupId>
     <artifactId>velocity-limbo-handler</artifactId>
-    <version>1.4.0-snapshot</version>
+    <version>1.5.0-snapshot</version>
     <packaging>jar</packaging>
 
     <name>velocity-limbo-handler</name>

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -260,7 +260,15 @@ public class VelocityLimboHandler {
 
                 // Check if maintenance mode is enabled on Backend server
                 if (Utility.isServerInMaintenance(previousServer.getServerInfo().getName())) {
-                    return;
+                    // Check if the user has bypass permission for Maintenance or is admin
+
+                    logger.info(String.valueOf(nextPlayer.hasPermission("maintenance.admin")));
+
+                    if (nextPlayer.hasPermission("maintenance.admin") || nextPlayer.hasPermission("maintenance.bypass") || nextPlayer.hasPermission("maintenance.singleserver.bypass." + limboName)) {
+                        logger.info(nextPlayer.getUsername() + " bypassed maintenance to " + previousServer.getServerInfo().getName() + " from " + limboName + " Server");
+                    } else {
+                        return;
+                    }
                 }
 
                 Utility.logInformational(String.format("Connecting %s to %s.", nextPlayer.getUsername(), previousServer.getServerInfo().getName()));

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -262,8 +262,6 @@ public class VelocityLimboHandler {
                 if (Utility.isServerInMaintenance(previousServer.getServerInfo().getName())) {
                     // Check if the user has bypass permission for Maintenance or is admin
 
-                    logger.info(String.valueOf(nextPlayer.hasPermission("maintenance.admin")));
-
                     if (nextPlayer.hasPermission("maintenance.admin") || nextPlayer.hasPermission("maintenance.bypass") || nextPlayer.hasPermission("maintenance.singleserver.bypass." + limboName)) {
                         logger.info(nextPlayer.getUsername() + " bypassed maintenance to " + previousServer.getServerInfo().getName() + " from " + limboName + " Server");
                     } else {


### PR DESCRIPTION
Added permission checking for Maintenance servers, to let people with `maintenance.bypass`, `maintenance.admin` or `maintenance.singleserver.bypass.[server]` still reconnect to the server from the Limbo Server

Just utilising
```java
player.hasPermission("permission")
```