### PR TITLE
Fix queue removal and tidy code

### DIFF
--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -5,7 +5,7 @@ import com.akselglyholt.velocityLimboHandler.commands.CommandBlocker;
 import com.akselglyholt.velocityLimboHandler.listeners.CommandExecuteEventListener;
 import com.akselglyholt.velocityLimboHandler.listeners.ConnectionListener;
 import com.akselglyholt.velocityLimboHandler.listeners.PreConnectEventListener;
-import com.akselglyholt.velocityLimboHandler.misc.MessageFormater;
+import com.akselglyholt.velocityLimboHandler.misc.MessageFormatter;
 import com.akselglyholt.velocityLimboHandler.misc.Utility;
 import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
 import com.google.inject.Inject;
@@ -30,7 +30,6 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bstats.charts.SingleLineChart;
 import org.bstats.velocity.Metrics;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +45,6 @@ import java.util.logging.Logger;
 
 @Plugin(id = "velocity-limbo-handler", name = "VelocityLimboHandler", authors = "Aksel Glyholt", version = "${project.version}")
 public class VelocityLimboHandler {
-    private static final org.slf4j.Logger log = LoggerFactory.getLogger(VelocityLimboHandler.class);
     private static ProxyServer proxyServer;
     private static Logger logger;
     private static RegisteredServer limboServer;
@@ -302,20 +300,24 @@ public class VelocityLimboHandler {
                         String combinedErrorMessage = (errorMessage + " " + reasonFromComponent).toLowerCase();
 
                         if (combinedErrorMessage.contains("ban") || combinedErrorMessage.contains("banned")) {
-                            String formatedMsg = MessageFormater.formatMessage(bannedMsg, finalNextPlayer);
+                            String formatedMsg = MessageFormatter.formatMessage(bannedMsg, finalNextPlayer);
 
                             finalNextPlayer.sendMessage(miniMessage.deserialize(formatedMsg));
                             // Mark them with an issue instead of kicking
                             playerManager.addPlayerWithIssue(finalNextPlayer, "banned");
+                            // Remove them from the reconnection queue to avoid blocking others
+                            playerManager.removePlayerFromQueue(finalNextPlayer);
                             return;
                         }
 
                         if (combinedErrorMessage.contains("whitelist") || combinedErrorMessage.contains("not whitelisted")) {
-                            String formatedMsg = MessageFormater.formatMessage(whitelistedMsg, finalNextPlayer);
+                            String formatedMsg = MessageFormatter.formatMessage(whitelistedMsg, finalNextPlayer);
 
                             finalNextPlayer.sendMessage(miniMessage.deserialize(formatedMsg));
                             // Mark them with an issue instead of kicking
                             playerManager.addPlayerWithIssue(finalNextPlayer, "not_whitelisted");
+                            // Remove them from the reconnection queue to avoid blocking others
+                            playerManager.removePlayerFromQueue(finalNextPlayer);
                             return;
                         }
 
@@ -328,7 +330,7 @@ public class VelocityLimboHandler {
                             String reason = PlainTextComponentSerializer.plainText().serialize(reasonComponent.get()).toLowerCase();
 
                             if (reason.contains("whitelist") || reason.contains("not whitelisted")) {
-                                String formatedMsg = MessageFormater.formatMessage(whitelistedMsg, finalNextPlayer);
+                                String formatedMsg = MessageFormatter.formatMessage(whitelistedMsg, finalNextPlayer);
 
                                 finalNextPlayer.sendMessage(miniMessage.deserialize(formatedMsg));
                                 // Instead of kicking and removing the player, mark them with an issue
@@ -339,7 +341,7 @@ public class VelocityLimboHandler {
                             }
 
                             if (reason.contains("ban") || reason.contains("banned")) {
-                                String formatedMsg = MessageFormater.formatMessage(bannedMsg, finalNextPlayer);
+                                String formatedMsg = MessageFormatter.formatMessage(bannedMsg, finalNextPlayer);
 
                                 finalNextPlayer.sendMessage(miniMessage.deserialize(formatedMsg));
                                 // Instead of kicking and removing the player, mark them with an issue
@@ -369,11 +371,11 @@ public class VelocityLimboHandler {
                     String issue = playerManager.getConnectionIssue(player);
 
                     if ("banned".equals(issue)) {
-                        String formatedMsg = MessageFormater.formatMessage(bannedMsg, player);
+                        String formatedMsg = MessageFormatter.formatMessage(bannedMsg, player);
 
                         player.sendMessage(miniMessage.deserialize(formatedMsg));
                     } else if ("not_whitelisted".equals(issue)) {
-                        String formatedMsg = MessageFormater.formatMessage(whitelistedMsg, player);
+                        String formatedMsg = MessageFormatter.formatMessage(whitelistedMsg, player);
 
                         player.sendMessage(miniMessage.deserialize(formatedMsg));
                     }
@@ -383,7 +385,7 @@ public class VelocityLimboHandler {
                 RegisteredServer previousServer = playerManager.getPreviousServer(player);
 
                 if (Utility.isServerInMaintenance(previousServer.getServerInfo().getName())) {
-                    String formatedMsg = MessageFormater.formatMessage(maintenanceModeMsg, player);
+                    String formatedMsg = MessageFormatter.formatMessage(maintenanceModeMsg, player);
 
                     player.sendMessage(miniMessage.deserialize(formatedMsg));
                     return;
@@ -394,7 +396,7 @@ public class VelocityLimboHandler {
 
                 int position = playerManager.getQueuePosition(player);
                 if (position == -1) continue;
-                String formatedQueuePositionMsg = MessageFormater.formatMessage(queuePositionMsg, player);
+                String formatedQueuePositionMsg = MessageFormatter.formatMessage(queuePositionMsg, player);
 
                 player.sendMessage(miniMessage.deserialize(formatedQueuePositionMsg));
             }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/CommandExecuteEventListener.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/CommandExecuteEventListener.java
@@ -9,7 +9,6 @@ import com.velocitypowered.api.proxy.ServerConnection;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
-import java.util.Map;
 import java.util.Optional;
 
 public class CommandExecuteEventListener {
@@ -28,7 +27,6 @@ public class CommandExecuteEventListener {
         Optional<ServerConnection> serverConnection = player.getCurrentServer();
 
         if (serverConnection.isPresent()) {
-            String serverName = serverConnection.get().getServerInfo().getName();
             String command = event.getCommand();
             String commandName = command.split(" ")[0].toLowerCase(); // Extract command name
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/MessageFormatter.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/MessageFormatter.java
@@ -3,9 +3,7 @@ package com.akselglyholt.velocityLimboHandler.misc;
 import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
 import com.velocitypowered.api.proxy.Player;
 
-import java.util.Optional;
-
-public class MessageFormater {
+public class MessageFormatter {
     public static String formatMessage(String msg, Player player) {
         if (msg.contains("[queue-position]")) {
             int position = VelocityLimboHandler.getPlayerManager().getQueuePosition(player);

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
@@ -1,6 +1,7 @@
 package com.akselglyholt.velocityLimboHandler.misc;
 
 import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
+import com.akselglyholt.velocityLimboHandler.misc.MessageFormatter;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import dev.dejvokep.boostedyaml.route.Route;
@@ -37,7 +38,7 @@ public class Utility {
             case "connection-issue" ->
                     miniMessage.deserialize("<dark_red>⚠ You had connection issues and were placed in Limbo.</dark_red>\n" +
                             "<gray>Try reconnecting or wait for a stable connection.</gray>");
-            default -> miniMessage.deserialize(MessageFormater.formatMessage(welcomeMsg, player));
+            default -> miniMessage.deserialize(MessageFormatter.formatMessage(welcomeMsg, player));
         };
 
         player.sendMessage(message);

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -1,7 +1,7 @@
 package com.akselglyholt.velocityLimboHandler.storage;
 
 import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
-import com.akselglyholt.velocityLimboHandler.misc.MessageFormater;
+import com.akselglyholt.velocityLimboHandler.misc.MessageFormatter;
 import com.akselglyholt.velocityLimboHandler.misc.Utility;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
@@ -10,10 +10,11 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class PlayerManager {
     private final Map<Player, RegisteredServer> playerData;
-    private final Queue<Player> reconnectQueue = new LinkedList<>();
+    private final Queue<Player> reconnectQueue = new ConcurrentLinkedQueue<>();
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
     private final Map<UUID, String> playerConnectionIssues = new ConcurrentHashMap<>();
 
@@ -37,7 +38,7 @@ public class PlayerManager {
         if (VelocityLimboHandler.isQueueEnabled() && !this.reconnectQueue.contains(player)) {
             this.reconnectQueue.add(player);
 
-            String formatedMsg = MessageFormater.formatMessage(queuePositionMsg, player);
+            String formatedMsg = MessageFormatter.formatMessage(queuePositionMsg, player);
             player.sendMessage(miniMessage.deserialize(formatedMsg));
         }
     }
@@ -45,6 +46,10 @@ public class PlayerManager {
 
     public void removePlayer(Player player) {
         this.playerData.remove(player);
+        this.reconnectQueue.remove(player);
+    }
+
+    public void removePlayerFromQueue(Player player) {
         this.reconnectQueue.remove(player);
     }
 


### PR DESCRIPTION
## Summary
- remove unused logging and command variables
- rename `MessageFormatter`
- replace reconnect queue with `ConcurrentLinkedQueue`
- add `removePlayerFromQueue` and use it when banned/whitelisted

## Testing
- `mvn -q test` *(fails: templating-maven-plugin unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68891d7bda7c832e817b1182b6efd5b4