### PR TITLE
Added per-server queue

### DIFF
--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -57,7 +57,7 @@ public class VelocityLimboHandler {
     private static YamlDocument messageConfig;
     private static boolean queueEnabled;
 
-    private final MiniMessage miniMessage = MiniMessage.miniMessage();
+    private static final MiniMessage miniMessage = MiniMessage.miniMessage();
 
     private static boolean maintenancePluginPresent = false;
     private static Object maintenanceAPI = null;
@@ -220,146 +220,29 @@ public class VelocityLimboHandler {
             Collection<Player> connectedPlayers = limboServer.getPlayersConnected();
             if (connectedPlayers.isEmpty()) return;
 
-            Player nextPlayer;
+            // Prune all in-active members
+            playerManager.pruneInactivePlayers();
 
+            // Loop through all servers, if queue is enabled
             if (queueEnabled) {
-                // Queue mode - get the next player from the queue
-                if (!playerManager.hasQueuedPlayers()) return;
-                nextPlayer = playerManager.getNextQueuedPlayer();
+                for (RegisteredServer server : proxyServer.getAllServers()) {
+                    // Queue mode – get the next player from the queue
+                    if (!playerManager.hasQueuedPlayers(server)) continue;
+                    Player nextPlayer = playerManager.getNextQueuedPlayer(server);
+
+                    reconnectPlayer(nextPlayer);
+                }
             } else {
-                // Non-queue mode - get the first connected player that doesn't have issues
-                nextPlayer = null;
+                Player nextPlayer = null;
+
                 for (Player player : connectedPlayers) {
-                    if (!playerManager.hasConnectionIssue(player)) {
+                    if (!playerManager.hasConnectionIssue(player) && player.isActive()) {
                         nextPlayer = player;
                         break;
                     }
                 }
 
-                // If all players have issues, just return
-                if (nextPlayer == null) return;
-            }
-
-            if (nextPlayer == null || !nextPlayer.isActive()) return;
-
-            // Skip players with connection issues
-            if (playerManager.hasConnectionIssue(nextPlayer)) return;
-
-            RegisteredServer previousServer = playerManager.getPreviousServer(nextPlayer);
-
-            // If enabled, check if a server responds to pings before connecting
-            try {
-                try {
-                    previousServer.ping().join(); // Check if the server is online
-                } catch (CompletionException completionException) {
-                    // Server failed to respond to ping request, return to prevent spam
-                    return;
-                }
-
-                // Check if maintenance mode is enabled on Backend server
-                if (Utility.isServerInMaintenance(previousServer.getServerInfo().getName())) {
-                    // Check if the user has bypass permission for Maintenance or is admin
-
-                    if (nextPlayer.hasPermission("maintenance.admin")
-                            || nextPlayer.hasPermission("maintenance.bypass")
-                            || nextPlayer.hasPermission("maintenance.singleserver.bypass." + limboName)
-                            || Utility.playerMaintenanceWhitelisted(nextPlayer)) {
-                        logger.info(nextPlayer.getUsername() + " bypassed maintenance to " + previousServer.getServerInfo().getName() + " from " + limboName + " Server");
-                    } else {
-                        return;
-                    }
-                }
-
-                Utility.logInformational(String.format("Connecting %s to %s.", nextPlayer.getUsername(), previousServer.getServerInfo().getName()));
-
-                Player finalNextPlayer = nextPlayer;
-
-                nextPlayer.createConnectionRequest(previousServer).connect().whenComplete((result, throwable) -> {
-                    if (result.isSuccessful()) {
-                        Utility.logInformational(String.format("Successfully reconnected %s to %s.", finalNextPlayer.getUsername(), previousServer.getServerInfo().getName()));
-                        playerManager.removePlayerIssue(finalNextPlayer);
-                        return;
-                    }
-
-                    Utility.logInformational(String.format("Connection failed for %s to %s. Result status: %s", finalNextPlayer.getUsername(), previousServer.getServerInfo().getName(), result.getStatus()));
-
-                    if (throwable != null) {
-                        // Get the error message from throwable
-                        String errorMessage = throwable.getMessage();
-                        if (errorMessage == null) {
-                            errorMessage = "";
-                        }
-
-                        // Also check the result component if available
-                        String reasonFromComponent = "";
-                        if (result.getReasonComponent().isPresent()) {
-                            reasonFromComponent = PlainTextComponentSerializer.plainText().serialize(result.getReasonComponent().get());
-                        }
-
-                        // Check both the throwable message and the component reason
-                        String combinedErrorMessage = (errorMessage + " " + reasonFromComponent).toLowerCase();
-
-                        if (combinedErrorMessage.contains("ban") || combinedErrorMessage.contains("banned")) {
-                            String formatedMsg = MessageFormatter.formatMessage(bannedMsg, finalNextPlayer);
-
-                            finalNextPlayer.sendMessage(miniMessage.deserialize(formatedMsg));
-                            // Mark them with an issue instead of kicking
-                            playerManager.addPlayerWithIssue(finalNextPlayer, "banned");
-                            // Remove them from the reconnection queue to avoid blocking others
-                            playerManager.removePlayerFromQueue(finalNextPlayer);
-                            return;
-                        }
-
-                        if (combinedErrorMessage.contains("whitelist") || combinedErrorMessage.contains("not whitelisted")) {
-                            String formatedMsg = MessageFormatter.formatMessage(whitelistedMsg, finalNextPlayer);
-
-                            finalNextPlayer.sendMessage(miniMessage.deserialize(formatedMsg));
-                            // Mark them with an issue instead of kicking
-                            playerManager.addPlayerWithIssue(finalNextPlayer, "not_whitelisted");
-                            // Remove them from the reconnection queue to avoid blocking others
-                            playerManager.removePlayerFromQueue(finalNextPlayer);
-                            return;
-                        }
-
-                        // Handle any other connection errors
-                        finalNextPlayer.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + (errorMessage.isEmpty() ? reasonFromComponent : errorMessage) + "</red>"));
-                    } else {
-                        // Handle case where we have a result but no throwable
-                        Optional<Component> reasonComponent = result.getReasonComponent();
-                        if (reasonComponent.isPresent()) {
-                            String reason = PlainTextComponentSerializer.plainText().serialize(reasonComponent.get()).toLowerCase();
-
-                            if (reason.contains("whitelist") || reason.contains("not whitelisted")) {
-                                String formatedMsg = MessageFormatter.formatMessage(whitelistedMsg, finalNextPlayer);
-
-                                finalNextPlayer.sendMessage(miniMessage.deserialize(formatedMsg));
-                                // Instead of kicking and removing the player, mark them with an issue
-                                playerManager.addPlayerWithIssue(finalNextPlayer, "not_whitelisted");
-                                // Remove them from the reconnection queue but keep them in limbo
-                                playerManager.removePlayer(finalNextPlayer);
-                                return;
-                            }
-
-                            if (reason.contains("ban") || reason.contains("banned")) {
-                                String formatedMsg = MessageFormatter.formatMessage(bannedMsg, finalNextPlayer);
-
-                                finalNextPlayer.sendMessage(miniMessage.deserialize(formatedMsg));
-                                // Instead of kicking and removing the player, mark them with an issue
-                                playerManager.addPlayerWithIssue(finalNextPlayer, "banned");
-                                // Remove them from the reconnection queue but keep them in limbo
-                                playerManager.removePlayer(finalNextPlayer);
-                                return;
-                            }
-
-
-                            finalNextPlayer.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + reason + "</red>"));
-                        }
-                    }
-                });
-
-                //playerManager.removePlayer(nextPlayer);
-            } catch (CompletionException exception) {
-                // Prevent console from being spammed when a server is offline and ping-check is disabled
+                reconnectPlayer(nextPlayer);
             }
         }).repeat(reconnectInterval, TimeUnit.SECONDS).schedule();
 
@@ -405,5 +288,130 @@ public class VelocityLimboHandler {
 
     public static boolean isQueueEnabled() {
         return queueEnabled;
+    }
+
+    private static void reconnectPlayer(Player player) {
+        if (player == null || !player.isActive()) return;
+
+        RegisteredServer previousServer = playerManager.getPreviousServer(player);
+
+        // If enabled, check if a server responds to pings before connecting
+        try {
+            try {
+                previousServer.ping().join(); // Check if the server is online
+            } catch (CompletionException completionException) {
+                // Server failed to respond to ping request, return to prevent spam
+                return;
+            }
+
+            // Check if maintenance mode is enabled on Backend Server
+            if (Utility.isServerInMaintenance(previousServer.getServerInfo().getName())) {
+                // Check if the user has bypass permission for Maintenance or is admin
+                if (player.hasPermission("maintenance.admin")
+                        || player.hasPermission("maintenance.bypass")
+                        || player.hasPermission("maintenance.singleserver.bypass." + previousServer.getServerInfo().getName())) {
+                    logger.info("[Maintenance Bypass] " + player.getUsername() + " bypassed queue to join " + previousServer.getServerInfo().getName());
+                } else {
+                    return;
+                }
+            }
+
+            Utility.logInformational(String.format("Connecting %s to %s", player.getUsername(), previousServer.getServerInfo().getName()));
+
+            player.createConnectionRequest(previousServer).connect().whenComplete(((result, throwable) -> {
+                if (result.isSuccessful()) {
+                    Utility.logInformational(String.format("Successfully reconnected %s to %s", player.getUsername(), previousServer.getServerInfo().getName()));
+                    playerManager.removePlayerIssue(player);
+                    return;
+                }
+
+                Utility.logInformational(String.format("Connection failed for %s to %s. Result status: %s",
+                        player.getUsername(),
+                        previousServer.getServerInfo().getName(),
+                        result.getStatus()));
+
+                if (throwable != null) {
+                    // Get the error message from throwable
+                    String errorMessage = throwable.getMessage();
+                    if (errorMessage == null) errorMessage = "";
+
+                    // Also check the result component if available
+                    String reasonFromComponent = "";
+                    if (result.getReasonComponent().isPresent()) {
+                        reasonFromComponent = PlainTextComponentSerializer.plainText().serialize(result.getReasonComponent().get());
+                    }
+
+                    // Check both the throwable message and the component reason
+                    String combinedErrorMessage = (errorMessage + " " + reasonFromComponent).toLowerCase();
+
+                    if (combinedErrorMessage.contains("ban") || combinedErrorMessage.contains("banned")) {
+                        String formattedMsg = MessageFormatter.formatMessage(bannedMsg, player);
+
+                        player.sendMessage(miniMessage.deserialize(formattedMsg));
+
+                        // Mark them with an issue instead of kicking
+                        playerManager.addPlayerWithIssue(player, "banned");
+
+                        // Remove them from the reconnection queue to avoid blocking others
+                        playerManager.removePlayerFromQueue(player);
+                        return;
+                    }
+
+                    if (combinedErrorMessage.contains("whitelist") || combinedErrorMessage.contains("not whitelisted")) {
+                        String formattedMsg = MessageFormatter.formatMessage(whitelistedMsg, player);
+
+                        player.sendMessage(miniMessage.deserialize(formattedMsg));
+
+                        // Mark them with an issue instead of kicking
+                        playerManager.addPlayerWithIssue(player, "not_whitelisted");
+
+                        // Remove them from the reconnection queue to avoid blocking others
+                        playerManager.removePlayerFromQueue(player);
+                        return;
+                    }
+
+                    // Handle any other connection errors
+                    player.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + (errorMessage.isEmpty() ? reasonFromComponent : errorMessage) + "</red>"));
+                } else {
+                    // Handle case where we have a result but no throwable
+                    Optional<Component> reasonComponent = result.getReasonComponent();
+
+                    if (reasonComponent.isPresent()) {
+                        String reason = PlainTextComponentSerializer.plainText().serialize(reasonComponent.get()).toLowerCase();
+
+                        if (reason.contains("ban") || reason.contains("banned")) {
+                            String formattedMsg = MessageFormatter.formatMessage(bannedMsg, player);
+
+                            player.sendMessage(miniMessage.deserialize(formattedMsg));
+
+                            // Mark them with an issue instead of kicking
+                            playerManager.addPlayerWithIssue(player, "banned");
+
+                            // Remove them from the reconnection queue to avoid blocking others
+                            playerManager.removePlayerFromQueue(player);
+                            return;
+                        }
+
+                        if (reason.contains("whitelist") || reason.contains("not whitelisted")) {
+                            String formattedMsg = MessageFormatter.formatMessage(whitelistedMsg, player);
+
+                            player.sendMessage(miniMessage.deserialize(formattedMsg));
+
+                            // Mark them with an issue instead of kicking
+                            playerManager.addPlayerWithIssue(player, "not_whitelisted");
+
+                            // Remove them from the reconnection queue to avoid blocking others
+                            playerManager.removePlayerFromQueue(player);
+                            return;
+                        }
+
+                        // Handle any other connection errors
+                        player.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + reason + "</red>"));
+                    }
+                }
+            }));
+        } catch (CompletionException exception) {
+            // Prevent console from being spammed when a server is offline and ping-check is disabled
+        }
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -8,13 +8,16 @@ import com.velocitypowered.api.proxy.server.RegisteredServer;
 import dev.dejvokep.boostedyaml.route.Route;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class PlayerManager {
     private final Map<Player, RegisteredServer> playerData;
-    private final Queue<Player> reconnectQueue = new ConcurrentLinkedQueue<>();
+    private final Map<RegisteredServer, Queue<Player>> reconnectQueues = new ConcurrentHashMap<>();
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
     private final Map<UUID, String> playerConnectionIssues = new ConcurrentHashMap<>();
 
@@ -35,8 +38,9 @@ public class PlayerManager {
         Utility.sendWelcomeMessage(player, null);
 
         // Only maintain a reconnect queue when queue mode is enabled
-        if (VelocityLimboHandler.isQueueEnabled() && !this.reconnectQueue.contains(player)) {
-            this.reconnectQueue.add(player);
+        Queue<Player> queue = reconnectQueues.computeIfAbsent(registeredServer, s -> new ConcurrentLinkedQueue<>());
+        if (VelocityLimboHandler.isQueueEnabled() && !queue.contains(player)) {
+            addPlayerToQueue(player, registeredServer);
 
             String formatedMsg = MessageFormatter.formatMessage(queuePositionMsg, player);
             player.sendMessage(miniMessage.deserialize(formatedMsg));
@@ -46,11 +50,7 @@ public class PlayerManager {
 
     public void removePlayer(Player player) {
         this.playerData.remove(player);
-        this.reconnectQueue.remove(player);
-    }
-
-    public void removePlayerFromQueue(Player player) {
-        this.reconnectQueue.remove(player);
+        removePlayerFromQueue(player);
     }
 
     public RegisteredServer getPreviousServer(Player player) {
@@ -61,27 +61,41 @@ public class PlayerManager {
         return playerData.containsKey(player);
     }
 
-    public Player getNextQueuedPlayer() {
-        return reconnectQueue.peek();
+    public void addPlayerToQueue(Player player, RegisteredServer server) {
+        reconnectQueues.computeIfAbsent(server, s -> new ConcurrentLinkedQueue<>()).add(player);
     }
 
-    public boolean hasQueuedPlayers() {
-        return !reconnectQueue.isEmpty();
+    public void removePlayerFromQueue(Player player) {
+        RegisteredServer server = this.playerData.getOrDefault(player, VelocityLimboHandler.getDirectConnectServer());
+
+        Queue<Player> queue = reconnectQueues.get(server);
+        if (queue != null) queue.remove(player);
+    }
+
+    public Player getNextQueuedPlayer(RegisteredServer server) {
+        Queue<Player> queue = reconnectQueues.get(server);
+        return queue == null ? null : queue.peek();
+    }
+
+    public boolean hasQueuedPlayers(RegisteredServer server) {
+        Queue<Player> queue = reconnectQueues.get(server);
+        return queue != null && !queue.isEmpty();
     }
 
     public int getQueuePosition(Player player) {
+        RegisteredServer server = getPreviousServer(player);
+
+        Queue<Player> queue = reconnectQueues.get(server);
+        if (queue == null) return -1;
+
         int position = 1;
-        for (Player p : reconnectQueue) {
-            if (p.equals(player)) {
-                return position;
-            }
+        for (Player p : queue) {
+            if (p.equals(player)) return position;
             position++;
         }
-        return -1; // Player is not in the queue
-    }
 
-    public Queue<Player> getReconnectQueue() {
-        return reconnectQueue;
+        return -1;
+
     }
 
     public void addPlayerWithIssue(Player player, String issue) {
@@ -98,5 +112,12 @@ public class PlayerManager {
 
     public void removePlayerIssue(Player player) {
         playerConnectionIssues.remove(player.getUniqueId());
+    }
+
+    public void pruneInactivePlayers() {
+        for (Queue<Player> queue : reconnectQueues.values()) {
+            queue.removeIf(p -> !p.isActive());
+        }
+        playerData.keySet().removeIf(p -> !p.isActive());
     }
 }


### PR DESCRIPTION
**Summary:**
This PR refactors the existing global reconnect queue into **per-server reconnect queues**, allowing each target server to maintain its own queue of players. This sets the foundation for better load management, fairness, and future expansion (e.g., priority queueing or per-server limits).

---

### Changes

* Introduced `Map<RegisteredServer, Queue<Player>> reconnectQueues` in `PlayerManager`
* Replaced single `reconnectQueue` with per-server logic
* Updated methods:

  * `addPlayerToQueue(Player, RegisteredServer)`
  * `removePlayerFromQueue(Player)`
  * `getNextQueuedPlayer(RegisteredServer)`
  * `getQueuePosition(Player)` (now server-specific)
* Added `getPlayerTargetServer(Player)` to resolve queue context per player
* Pruned inactive players from all queues in `pruneInactivePlayers()`
* Improved null-safety with `computeIfAbsent()` and fallback checks

---

### Notes for Testing

* Players joining the limbo should now be queued based on their intended target server
* Players are only added once per queue and receive the correct queue position
* Players are removed from the correct queue upon disconnect or successful reconnection
* Queue notifications and reconnection logic should reflect per-server behavior

---

### Why this matters

This refactor:

* Eliminates fairness issues caused by one global queue
* Prepares the plugin for supporting server-specific rate limits, permissions, and priorities
* Allows for more flexible reconnection logic and better scalability on large Velocity networks