### PR TITLE
Fixed whitelisted players stuck behind non-whitelisted

### DIFF
--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
@@ -195,5 +195,4 @@ public class Utility {
             return false;
         }
     }
-
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -120,4 +120,26 @@ public class PlayerManager {
         }
         playerData.keySet().removeIf(p -> !p.isActive());
     }
+
+    /**
+     * @param server the server of which you need to find the first whitelisted/permission allow player
+     * @return Player object
+     */
+    public static Player findFirstMaintenanceAllowedPlayer(RegisteredServer server) {
+        // Find the queue for the server
+        Queue<Player> queue = VelocityLimboHandler.getPlayerManager().reconnectQueues.get(server);
+        if (queue == null) return null;
+
+        // Loop through all players and check if any match is found
+        for (Player player : queue) {
+            if (player.hasPermission("maintenance.admin")
+                    || player.hasPermission("maintenance.bypass")
+                    || player.hasPermission("maintenance.singleserver.bypass." + server.getServerInfo().getName())
+                    || Utility.playerMaintenanceWhitelisted(player)) {
+                return player;
+            }
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
Fixed bug where if a player had whitelist in the Maintenance plugin, and they were number 2 in the queue, they wouldn't be able to reconnect, since they were stuck behind the player in number 1 queue position.

Added this helper function to do this, in `PlayerManager.java`
```java
/**
     * @param server the server of which you need to find the first whitelisted/permission allow player
     * @return Player object
     */
    public static Player findFirstMaintenanceAllowedPlayer(RegisteredServer server) {
        // Find the queue for the server
        Queue<Player> queue = VelocityLimboHandler.getPlayerManager().reconnectQueues.get(server);
        if (queue == null) return null;

        // Loop through all players and check if any match is found
        for (Player player : queue) {
            if (player.hasPermission("maintenance.admin")
                    || player.hasPermission("maintenance.bypass")
                    || player.hasPermission("maintenance.singleserver.bypass." + server.getServerInfo().getName())
                    || Utility.playerMaintenanceWhitelisted(player)) {
                return player;
            }
        }

        return null;
    }
    ```