### PR TITLE
Feature/auth handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akselglyholt</groupId>
     <artifactId>velocity-limbo-handler</artifactId>
-    <version>1.5.1-snapshot</version>
+    <version>1.6.0-snapshot</version>
     <packaging>jar</packaging>
 
     <name>velocity-limbo-handler</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akselglyholt</groupId>
     <artifactId>velocity-limbo-handler</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1-snapshot</version>
     <packaging>jar</packaging>
 
     <name>velocity-limbo-handler</name>

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -47,6 +47,7 @@ import java.util.logging.Logger;
 
 @Plugin(id = "velocity-limbo-handler", name = "VelocityLimboHandler", authors = "Aksel Glyholt", version = VersionInfo.VERSION)
 public class VelocityLimboHandler {
+    private static VelocityLimboHandler instance;
     private static ProxyServer proxyServer;
     private static Logger logger = Logger.getLogger("Limbo Handler");
     private static RegisteredServer limboServer;
@@ -78,6 +79,7 @@ public class VelocityLimboHandler {
     @Inject
     public VelocityLimboHandler(ProxyServer server, @DataDirectory Path dataDirectory, Metrics.Factory metricsFactoryInstance) {
         proxyServer = server;
+        instance = this;
         //logger = loggerInstance;
 
         try {
@@ -262,8 +264,9 @@ public class VelocityLimboHandler {
                             if (player.hasPermission("maintenance.admin")
                                     || player.hasPermission("maintenance.bypass")
                                     || player.hasPermission("maintenance.singleserver.bypass." + previousServer.getServerInfo().getName())
-                                    || Utility.playerMaintenanceWhitelisted(player)) {
-                                // Can't join server whilst in Maintenance, so continue to next
+                                    || Utility.playerMaintenanceWhitelisted(player)
+                                    || authManager.isAuthBlocked(player)) {
+                                // Can't join server whilst in Maintenance, or player is Auth Blocked so continue to next
                                 continue;
                             }
                         }
@@ -430,5 +433,13 @@ public class VelocityLimboHandler {
         }
 
         return false;
+    }
+
+    public static VelocityLimboHandler getInstance() {
+        return instance;
+    }
+
+    public static ReconnectBlocker getReconnectBlocker() {
+        return reconnectBlocker;
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/AuthHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/AuthHandler.java
@@ -1,0 +1,11 @@
+package com.akselglyholt.velocityLimboHandler.auth;
+
+import com.velocitypowered.api.proxy.Player;
+
+public interface AuthHandler extends AutoCloseable {
+    String name();
+    boolean isActive(); // detection succeeded
+    void onPlayerJoin(Player player);      // usually block here
+    void onShutdown();                     // cleanup if needed
+    @Override default void close() { onShutdown(); }
+}

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/AuthManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/AuthManager.java
@@ -17,7 +17,8 @@ public final class AuthManager implements AutoCloseable {
     private AuthHandler active = new NoopHandler();
 
     public AuthManager(Object plugin, ProxyServer proxy, ReconnectBlocker blocker) {
-        this.proxy = proxy; this.blocker = blocker;
+        this.proxy = proxy;
+        this.blocker = blocker;
         // order matters if multiple are present
         handlers.add(new LibreLoginHandler(proxy, blocker));
         // add future handlers here
@@ -30,11 +31,17 @@ public final class AuthManager implements AutoCloseable {
 
     private void selectActive() {
         for (var h : handlers) {
-            if (h.isActive()) { active = h; return; }
+            if (h.isActive()) {
+                active = h;
+                return;
+            }
         }
     }
 
-    @Override public void close() { active.close(); }
+    @Override
+    public void close() {
+        active.close();
+    }
 
     public boolean isAuthBlocked(Player p) {
         return this.blocker != null && blocker.isBlocked(p.getUniqueId());

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/AuthManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/AuthManager.java
@@ -1,0 +1,42 @@
+package com.akselglyholt.velocityLimboHandler.auth;
+
+import com.akselglyholt.velocityLimboHandler.auth.handlers.LibreLoginHandler;
+import com.akselglyholt.velocityLimboHandler.auth.handlers.NoopHandler;
+import com.akselglyholt.velocityLimboHandler.misc.ReconnectBlocker;
+import com.velocitypowered.api.event.player.PlayerChooseInitialServerEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class AuthManager implements AutoCloseable {
+    private final ProxyServer proxy;
+    private final ReconnectBlocker blocker;
+    private final List<AuthHandler> handlers = new ArrayList<>();
+    private AuthHandler active = new NoopHandler();
+
+    public AuthManager(Object plugin, ProxyServer proxy, ReconnectBlocker blocker) {
+        this.proxy = proxy; this.blocker = blocker;
+        // order matters if multiple are present
+        handlers.add(new LibreLoginHandler(proxy, blocker));
+        // add future handlers here
+        selectActive();
+        proxy.getEventManager().register(plugin, PlayerChooseInitialServerEvent.class, evt -> {
+            Player p = evt.getPlayer();
+            active.onPlayerJoin(p);
+        });
+    }
+
+    private void selectActive() {
+        for (var h : handlers) {
+            if (h.isActive()) { active = h; return; }
+        }
+    }
+
+    @Override public void close() { active.close(); }
+
+    public boolean isAuthBlocked(Player p) {
+        return this.blocker != null && blocker.isBlocked(p.getUniqueId());
+    }
+}

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginHandler.java
@@ -90,7 +90,8 @@ public class LibreLoginHandler implements AuthHandler {
             for (var f : types.getClass().getFields()) {
                 try {
                     Object val = f.get(types);
-                } catch (IllegalAccessException ignored) {}
+                } catch (IllegalAccessException ignored) {
+                }
             }
 
             // Use the exact field name from your logs
@@ -139,7 +140,11 @@ public class LibreLoginHandler implements AuthHandler {
     }
 
     private static java.lang.reflect.Method safeMethod(Class<?> c, String name, Class<?>... params) {
-        try { return c.getMethod(name, params); } catch (NoSuchMethodException e) { return null; }
+        try {
+            return c.getMethod(name, params);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
     }
 
     private Player extractPlayerFromLibreEvent(Object event) {
@@ -167,7 +172,8 @@ public class LibreLoginHandler implements AuthHandler {
                     }
                 }
             }
-        } catch (Exception ignored) {}
+        } catch (Exception ignored) {
+        }
         return null;
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginHandler.java
@@ -56,7 +56,6 @@ public class LibreLoginHandler implements AuthHandler {
 
         proxy.getScheduler().buildTask(VelocityLimboHandler.getInstance(), () -> {
             if (blocker.isBlocked(player.getUniqueId())) {
-                logger.info("[VLH] Player " + player.getUsername() + " failed to authenticate in time — kicking.");
                 player.disconnect(MiniMessage.miniMessage().deserialize("<red>Authentication timed out. Please rejoin.</red>"));
                 blocker.unblock(player.getUniqueId()); // Clean up
             }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginHandler.java
@@ -1,0 +1,176 @@
+package com.akselglyholt.velocityLimboHandler.auth.handlers;
+
+import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
+import com.akselglyholt.velocityLimboHandler.auth.AuthHandler;
+import com.akselglyholt.velocityLimboHandler.misc.ReconnectBlocker;
+import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
+import com.velocitypowered.api.plugin.PluginContainer;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+public class LibreLoginHandler implements AuthHandler {
+    private final ProxyServer proxy;
+    private final ReconnectBlocker blocker;
+    private volatile boolean active;
+    private final Logger logger = VelocityLimboHandler.getLogger();
+    private final PlayerManager playerManager = VelocityLimboHandler.getPlayerManager();
+
+    public LibreLoginHandler(ProxyServer proxy, ReconnectBlocker blocker) {
+        this.proxy = proxy;
+        this.blocker = blocker;
+
+        // Detection by plugin id or class existence
+        this.active = proxy.getPluginManager().getPlugin("librelogin").isPresent()
+                || classPresent("xyz.kyngs.librelogin.api.LibreLoginPlugin");
+        logger.info("LibreLogin plugin detected! Integrating now");
+        if (active) tryHook();
+    }
+
+    @Override
+    public String name() {
+        return "LibreLogin";
+    }
+
+    @Override
+    public boolean isActive() {
+        return active;
+    }
+
+    @Override
+    public void onPlayerJoin(Player player) {
+        if (!active) return;
+
+        System.out.println(player.getUsername());
+
+        blocker.block(player.getUniqueId(), "auth", Duration.ofMinutes(2));
+    }
+
+    private void tryHook() {
+        try {
+            // 1) Get bootstrap (VelocityBootstrap) instance
+            var containerOpt = proxy.getPluginManager().getPlugin("librelogin");
+            var instanceOpt = containerOpt.flatMap(com.velocitypowered.api.plugin.PluginContainer::getInstance);
+            if (instanceOpt.isEmpty()) {
+                logger.warning("LibreLogin plugin instance not available.");
+                return;
+            }
+            Object bootstrap = instanceOpt.get();
+
+            // 2) bootstrap.getLibreLogin() -> core plugin
+            Method getLibreLogin = bootstrap.getClass().getMethod("getLibreLogin");
+            Object core = getLibreLogin.invoke(bootstrap);
+
+            // 3) core.getEventProvider()
+            Method getEventProvider = core.getClass().getMethod("getEventProvider");
+            Object eventProvider = getEventProvider.invoke(core);
+
+            // 4) provider.getTypes() and pick "authenticated"
+            Method getTypes = eventProvider.getClass().getMethod("getTypes");
+            Object types = getTypes.invoke(eventProvider);
+
+            // Log available event types (you already saw them)
+            for (var f : types.getClass().getFields()) {
+                try {
+                    Object val = f.get(types);
+                } catch (IllegalAccessException ignored) {}
+            }
+
+            // Use the exact field name from your logs
+            var authField = types.getClass().getField("authenticated");
+            Object authType = authField.get(types);
+
+            // 5) Subscribe: subscribe(EventType<T>, Consumer<T>)
+            Class<?> eventTypeClass = Class.forName("xyz.kyngs.librelogin.api.event.EventType");
+            Method subscribe = eventProvider.getClass().getMethod("subscribe", eventTypeClass, java.util.function.Consumer.class);
+
+            java.util.function.Consumer<Object> handler = (Object event) -> {
+                try {
+                    Player p = extractPlayerFromLibreEvent(event);
+                    if (p != null) {
+                        blocker.unblock(p.getUniqueId());
+                        // logger.info("Player " + p.getUsername() + " authenticated via LibreLogin — unblocked.");
+
+                        RegisteredServer server = playerManager.getPreviousServer(p);
+                        playerManager.addPlayer(p, server);
+                    } else {
+                        // Fallback: try UUID path
+                        Method getUser = safeMethod(event.getClass(), "getUser");
+                        if (getUser != null) {
+                            Object user = getUser.invoke(event);
+                            if (user != null) {
+                                Method getUuid = safeMethod(user.getClass(), "getUuid");
+                                if (getUuid != null) {
+                                    Object uuid = getUuid.invoke(user);
+                                    blocker.unblock((java.util.UUID) uuid);
+                                    // logger.info("Authenticated (UUID only) — unblocked.");
+                                }
+                            }
+                        }
+                    }
+                } catch (Exception ex) {
+                    logger.warning("Failed to process LibreLogin auth event: " + ex.getMessage());
+                }
+            };
+
+            subscribe.invoke(eventProvider, authType, handler);
+
+            logger.info("Subscribed to LibreLogin 'authenticated' event.");
+        } catch (Exception e) {
+            logger.warning("Failed to integrate with LibreLogin: " + e.getMessage());
+        }
+    }
+
+    private static java.lang.reflect.Method safeMethod(Class<?> c, String name, Class<?>... params) {
+        try { return c.getMethod(name, params); } catch (NoSuchMethodException e) { return null; }
+    }
+
+    private Player extractPlayerFromLibreEvent(Object event) {
+        try {
+            // Try event.getPlayer()
+            Method getPlayer = safeMethod(event.getClass(), "getPlayer");
+            if (getPlayer != null) {
+                Object p = getPlayer.invoke(event);
+                if (p instanceof Player) return (Player) p;
+            }
+            // Try event.getUser().getProxyPlayer()/getPlayer()
+            Method getUser = safeMethod(event.getClass(), "getUser");
+            if (getUser != null) {
+                Object user = getUser.invoke(event);
+                if (user != null) {
+                    Method proxyPlayer = safeMethod(user.getClass(), "getProxyPlayer");
+                    if (proxyPlayer != null) {
+                        Object p = proxyPlayer.invoke(user);
+                        if (p instanceof Player) return (Player) p;
+                    }
+                    Method getPlayer2 = safeMethod(user.getClass(), "getPlayer");
+                    if (getPlayer2 != null) {
+                        Object p = getPlayer2.invoke(user);
+                        if (p instanceof Player) return (Player) p;
+                    }
+                }
+            }
+        } catch (Exception ignored) {}
+        return null;
+    }
+
+
+    @Override
+    public void onShutdown() {
+
+    }
+
+    private static boolean classPresent(String fqn) {
+        try {
+            Class.forName(fqn, false, LibreLoginHandler.class.getClassLoader());
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/NoopHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/NoopHandler.java
@@ -1,0 +1,27 @@
+package com.akselglyholt.velocityLimboHandler.auth.handlers;
+
+import com.akselglyholt.velocityLimboHandler.auth.AuthHandler;
+import com.velocitypowered.api.proxy.Player;
+
+public final class NoopHandler implements AuthHandler {
+
+    @Override
+    public String name() {
+        return "Noop";
+    }
+
+    @Override
+    public boolean isActive() {
+        return true; // Always "active" so AuthManager has something
+    }
+
+    @Override
+    public void onPlayerJoin(Player player) {
+        // Do nothing
+    }
+
+    @Override
+    public void onShutdown() {
+        // Do nothing
+    }
+}

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/InMemoryReconnectBlocker.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/InMemoryReconnectBlocker.java
@@ -1,0 +1,26 @@
+package com.akselglyholt.velocityLimboHandler.misc;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class InMemoryReconnectBlocker implements ReconnectBlocker {
+    private static final class Entry { Instant until; String reason; }
+    private final ConcurrentHashMap<UUID, Entry> map = new ConcurrentHashMap<>();
+
+    @Override public void block(UUID id, String reason, Duration ttl) {
+        Entry e = new Entry();
+        e.until = Instant.now().plus(ttl);
+        e.reason = reason;
+        map.put(id, e);
+    }
+    @Override public void unblock(UUID id) { map.remove(id); }
+
+    @Override public boolean isBlocked(UUID id) {
+        Entry e = map.get(id);
+        if (e == null) return false;
+        if (Instant.now().isAfter(e.until)) { map.remove(id); return false; }
+        return true;
+    }
+}

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/InMemoryReconnectBlocker.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/InMemoryReconnectBlocker.java
@@ -1,26 +1,24 @@
 package com.akselglyholt.velocityLimboHandler.misc;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class InMemoryReconnectBlocker implements ReconnectBlocker {
-    private static final class Entry { Instant until; String reason; }
+    private static final class Entry { String reason; }
     private final ConcurrentHashMap<UUID, Entry> map = new ConcurrentHashMap<>();
 
-    @Override public void block(UUID id, String reason, Duration ttl) {
+    @Override public void block(UUID id, String reason) {
         Entry e = new Entry();
-        e.until = Instant.now().plus(ttl);
         e.reason = reason;
         map.put(id, e);
     }
-    @Override public void unblock(UUID id) { map.remove(id); }
+
+    @Override public void unblock(UUID id) {
+        map.remove(id);
+    }
 
     @Override public boolean isBlocked(UUID id) {
-        Entry e = map.get(id);
-        if (e == null) return false;
-        if (Instant.now().isAfter(e.until)) { map.remove(id); return false; }
-        return true;
+        return map.containsKey(id);
     }
 }
+

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/ReconnectBlocker.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/ReconnectBlocker.java
@@ -4,7 +4,7 @@ import java.time.Duration;
 import java.util.UUID;
 
 public interface ReconnectBlocker {
-    void block(UUID uuid, String reason, Duration ttl);
+    void block(UUID uuid, String reason);
     void unblock(UUID uuid);
     boolean isBlocked(UUID uuid);
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/ReconnectBlocker.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/ReconnectBlocker.java
@@ -1,0 +1,10 @@
+package com.akselglyholt.velocityLimboHandler.misc;
+
+import java.time.Duration;
+import java.util.UUID;
+
+public interface ReconnectBlocker {
+    void block(UUID uuid, String reason, Duration ttl);
+    void unblock(UUID uuid);
+    boolean isBlocked(UUID uuid);
+}

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -1,6 +1,7 @@
 package com.akselglyholt.velocityLimboHandler.storage;
 
 import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
+import com.akselglyholt.velocityLimboHandler.auth.AuthManager;
 import com.akselglyholt.velocityLimboHandler.misc.MessageFormatter;
 import com.akselglyholt.velocityLimboHandler.misc.Utility;
 import com.velocitypowered.api.proxy.Player;
@@ -20,8 +21,12 @@ public class PlayerManager {
     private final Map<RegisteredServer, Queue<Player>> reconnectQueues = new ConcurrentHashMap<>();
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
     private final Map<UUID, String> playerConnectionIssues = new ConcurrentHashMap<>();
-
     private static String queuePositionMsg;
+
+    private boolean isAuthBlocked(Player player) {
+        var am = VelocityLimboHandler.getAuthManager();
+        return am != null && am.isAuthBlocked(player);
+    }
 
     public PlayerManager() {
         this.playerData = new LinkedHashMap<>();
@@ -32,6 +37,8 @@ public class PlayerManager {
     public void addPlayer(Player player, RegisteredServer registeredServer) {
         // Don't override if the player is already registered
         if (this.playerData.containsKey(player)) return;
+
+        if (isAuthBlocked(player)) return;
 
         this.playerData.put(player, registeredServer);
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -58,6 +58,7 @@ public class PlayerManager {
     public void removePlayer(Player player) {
         removePlayerFromQueue(player);
         this.playerData.remove(player);
+        VelocityLimboHandler.getReconnectBlocker().unblock(player.getUniqueId());
     }
 
     public RegisteredServer getPreviousServer(Player player) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-file-version: 3
+file-version: 4
 
 # Server configs - These are settings you need to change!
 # The name of the limbo server in your velocity network
@@ -17,3 +17,5 @@ queue-notify-interval: 30 # The time in seconds (Default: 30)
 # A list of disabled commands, which will not work inside the Limbo server. Recommended commands are ones that the player can use to transfer server, like /server or /hub
 disabled-commands: ["server", "lobby", "hub"]
 
+# The time a player has to authenticate, if an Authentication plugin is installed, in seconds
+auth-timeout-seconds: 120 # Default 120


### PR DESCRIPTION
# Changelog

## Added

* **Auth gate for reconnects** via `ReconnectBlocker`. Players parked in Limbo by auth plugins won’t be reconnected until authorized.
* **LibreLogin auto-integration (Velocity)** using reflection:

  * Detects `librelogin` plugin and hooks through `getLibreLogin().getEventProvider()`.
  * Subscribes to the `authenticated` event to **unblock** players immediately after successful auth.
* **Queue hygiene**:

  * Blocked players are **not added** to per-server queues while authentication is pending.
  * Requeue on auth success by restoring the player to the correct per-server queue using their previous server.

## Changed

* `reconnectPlayer(...)` now **short-circuits** if the player is auth-blocked.
* `PlayerManager.addPlayer(...)` refuses to enqueue players who are still authenticating.

## Fixed

* **Startup/Guice container error** by moving `AuthManager` construction to `onProxyInitialization` and passing the proper plugin instance to event registration.
* Avoided NPEs by removing early caching of `AuthManager` inside `PlayerManager` and resolving it lazily.

## Implementation Notes

* No config needed. Integration is **automatic** if LibreLogin is present.
* Reflection targets:

  * Bootstrap: `getLibreLogin()`
  * Event provider: `getEventProvider()`
  * Event types: `eventProvider.getTypes()`
  * Subscribed type: `types.authenticated`
  * EventType class: `xyz.kyngs.librelogin.api.event.EventType`
* Safe fallbacks:

  * A TTL on blocks prevents permanent stuck states if events are missed.
  * Player extraction from events tries `event.getPlayer()` or `event.getUser().getProxyPlayer()/getPlayer()`.

## Testing

1. Install LibreLogin and start the proxy.
2. Join with an unauthenticated account:

   * Player is sent to Limbo.
   * Player is **not** enqueued and **not** reconnected.
3. Complete authentication:

   * `authenticated` event fires.
   * Player is **unblocked** and re-queued appropriately.
   * Reconnect proceeds when their turn comes.
4. Verify queue mode:

   * Blocked players do not hold the head of the queue.
   * Non-blocked players continue to reconnect as normal.

## Backwards Compatibility

* Behavior unchanged when LibreLogin is absent.
* No API breakages; changes are internal and opt-in via auto-detection.
