### PR TITLE
Bugfix: CloudNet Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - main
+      - *
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,10 @@ name: Build
 on:
   push:
     branches:
-      - *
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akselglyholt</groupId>
     <artifactId>velocity-limbo-handler</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2-snapshot</version>
     <packaging>jar</packaging>
 
     <name>velocity-limbo-handler</name>


### PR DESCRIPTION
Fixes issue #35 (No reconnect on Server Restart) by @Angry007-Julian

### Summary

This PR updates **PlayerManager** to rely on the server **name** instead of the server **object**.
This fixes compatibility issues with CloudNet, where server objects aren’t always stable or directly accessible.

### Changes

* Replaced usage of server objects with server names in `PlayerManager`
* Ensured lookups and assignments resolve correctly by name

### Impact

* Fixes CloudNet compatibility
* No impact expected for standard Velocity setups
* Simplifies server handling by avoiding object references
