### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/AkselGlyholt/velocity-limbo-handler/security/code-scanning/1](https://github.com/AkselGlyholt/velocity-limbo-handler/security/code-scanning/1)

The best way to fix this problem is to add a `permissions:` block to the workflow that explicitly limits `GITHUB_TOKEN` permissions to the minimum needed. For this particular workflow, since the steps only check out code, build with Maven, cache dependencies, and upload artifacts, the minimal permissions required are `contents: read`. The `actions/upload-artifact` does not require additional write permissions on the repository; it only uploads files to Action storage, not the repository. Therefore, adding the following block directly below the `name:` field (so it's at the root of the workflow) is ideal:

```yaml
permissions:
  contents: read
```

This ensures that all jobs use these restricted permissions by default.  
**Change:** Insert the block after line 1 in `.github/workflows/build.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
