### PR TITLE
Updated task-interval to milliseconds

### DIFF
--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class PlayerManager {
     private final Map<Player, String> playerData;
+    private final Map<Player, Boolean> connectingPlayers;
     private final Map<String, Queue<Player>> reconnectQueues = new ConcurrentHashMap<>();
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
     private final Map<UUID, String> playerConnectionIssues = new ConcurrentHashMap<>();
@@ -29,6 +30,7 @@ public class PlayerManager {
 
     public PlayerManager() {
         this.playerData = new LinkedHashMap<>();
+        this.connectingPlayers = new LinkedHashMap<>();
 
         queuePositionMsg = VelocityLimboHandler.getMessageConfig().getString(Route.from("queuePositionJoin"));
     }
@@ -58,6 +60,7 @@ public class PlayerManager {
     public void removePlayer(Player player) {
         removePlayerFromQueue(player);
         this.playerData.remove(player);
+        this.connectingPlayers.remove(player);
         VelocityLimboHandler.getReconnectBlocker().unblock(player.getUniqueId());
     }
 
@@ -162,5 +165,22 @@ public class PlayerManager {
         }
 
         return null;
+    }
+
+    // Check if player is in the hashmap
+    public boolean isPlayerConnecting(Player player) {
+        return this.connectingPlayers.containsKey(player);
+    }
+
+    /**
+     * @param player is the player of which you want to set the status of
+     * @param add    is whether you want to add the player, or remove it
+     */
+    public void setPlayerConnecting(Player player, Boolean add) {
+        if (add) {
+            this.connectingPlayers.put(player, true);
+        } else {
+            this.connectingPlayers.remove(player);
+        }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-file-version: 4
+file-version: 5
 
 # Server configs - These are settings you need to change!
 # The name of the limbo server in your velocity network
@@ -8,7 +8,7 @@ limbo-name: limbo # Default "limbo"
 direct-connect-server: lobby # Default "lobby"
 
 # How often the server should check if it can connect
-task-interval: 3 # The time in seconds (Default: 3)
+task-interval: 3000 # The time in milliseconds (Default: 3000)
 
 # How often should the user be notified of their position in the queue
 queue-enabled: true # Should players be reconnected through a queue (Default: true)


### PR DESCRIPTION
Updated `task-interval` to use milliseconds instead of seconds to allow for quicker reconnections when the queue is big

## New tech
Added `isPlayerConnecting` and `setPlayerConnecting` inside `PlayerManager.java`

These are to help with the reconnection loop to prevent multiple reconnect attempts while the player already is being rerouted. Should also help with performance