### PR TITLE
deprecated auth-timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akselglyholt</groupId>
     <artifactId>velocity-limbo-handler</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0-snapshot</version>
     <packaging>jar</packaging>
 
     <name>velocity-limbo-handler</name>

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginHandler.java
@@ -20,7 +20,6 @@ public class LibreLoginHandler implements AuthHandler {
     private volatile boolean active;
     private final Logger logger = VelocityLimboHandler.getLogger();
     private final PlayerManager playerManager = VelocityLimboHandler.getPlayerManager();
-    private final long timeoutSeconds = VelocityLimboHandler.getConfig().getInt("auth-timeout-seconds", 120);
 
     public LibreLoginHandler(ProxyServer proxy, ReconnectBlocker blocker) {
         this.proxy = proxy;
@@ -47,18 +46,6 @@ public class LibreLoginHandler implements AuthHandler {
         if (!active) return;
 
         blocker.block(player.getUniqueId(), "auth");
-
-        // Schedule kick after timeout (configurable)
-
-        if (timeoutSeconds <= 0) return;
-
-        proxy.getScheduler().buildTask(VelocityLimboHandler.getInstance(), () -> {
-            if (blocker.isBlocked(player.getUniqueId())) {
-                player.disconnect(MiniMessage.miniMessage().deserialize(VelocityLimboHandler.getMessageConfig().getString(Route.from("authTimeout"))));
-                player.disconnect(MiniMessage.miniMessage().deserialize("<red>Authentication timed out. Please rejoin.</red>"));
-                blocker.unblock(player.getUniqueId()); // Clean up
-            }
-        }).delay(Duration.ofSeconds(timeoutSeconds)).schedule();
     }
 
     private void tryHook() {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginNextHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginNextHandler.java
@@ -20,7 +20,6 @@ public class LibreLoginNextHandler implements AuthHandler {
     private volatile boolean active;
     private final Logger logger = VelocityLimboHandler.getLogger();
     private final PlayerManager playerManager = VelocityLimboHandler.getPlayerManager();
-    private final long timeoutSeconds = VelocityLimboHandler.getConfig().getInt("auth-timeout-seconds", 120);
 
     public LibreLoginNextHandler(ProxyServer proxy, ReconnectBlocker blocker) {
         this.proxy = proxy;
@@ -47,18 +46,6 @@ public class LibreLoginNextHandler implements AuthHandler {
         if (!active) return;
 
         blocker.block(player.getUniqueId(), "auth");
-
-        // Schedule kick after timeout (configurable)
-
-        if (timeoutSeconds <= 0) return;
-
-        proxy.getScheduler().buildTask(VelocityLimboHandler.getInstance(), () -> {
-            if (blocker.isBlocked(player.getUniqueId())) {
-                player.disconnect(MiniMessage.miniMessage().deserialize(VelocityLimboHandler.getMessageConfig().getString(Route.from("authTimeout"))));
-                player.disconnect(MiniMessage.miniMessage().deserialize("<red>Authentication timed out. Please rejoin.</red>"));
-                blocker.unblock(player.getUniqueId()); // Clean up
-            }
-        }).delay(Duration.ofSeconds(timeoutSeconds)).schedule();
     }
 
     private void tryHook() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-file-version: 5
+file-version: 6
 
 # Server configs - These are settings you need to change!
 # The name of the limbo server in your velocity network
@@ -16,6 +16,3 @@ queue-notify-interval: 30 # The time in seconds (Default: 30)
 
 # A list of disabled commands, which will not work inside the Limbo server. Recommended commands are ones that the player can use to transfer server, like /server or /hub
 disabled-commands: ["server", "lobby", "hub"]
-
-# The time a player has to authenticate, if an Authentication plugin is installed, in seconds
-auth-timeout-seconds: 120 # Default 120

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,4 +1,4 @@
-file-version: 2
+file-version: 3
 
 # You can change all messages inside this file.
 # Messages use minimessage format: https://docs.advntr.dev/minimessage/index.html
@@ -21,6 +21,3 @@ queuePositionJoin: "<yellow>You are in the queue. Position: [queue-position]"
 
 # Welcome messages
 welcomeMessage: "<blue>🌌 You were sent to Limbo.</blue> \n<gray>You will be reconnected when the system allows.</gray>"
-
-# Message for when the user doesn't authenticate in time.
-authTimeout: "<red>Authentication timed out. Please rejoin.</red>"


### PR DESCRIPTION
Deprecated `auth-timeout` as most authentication plugins already has a system like this in place, and there being 2 systems that try to do this at once may be confusing

Recommended by @MiguVT