### PR TITLE
feat: Implement disabling auto sendback for players in limbo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akselglyholt</groupId>
     <artifactId>velocity-limbo-handler</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <packaging>jar</packaging>
 
     <name>velocity-limbo-handler</name>

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -283,6 +283,7 @@ public class VelocityLimboHandler {
 
         // Schedule queue position notifier
         proxyServer.getScheduler().buildTask(this, () -> {
+            if (!config.getBoolean(Route.from("enable-sending-back"))) return;
             for (Player player : limboServer.getPlayersConnected()) {
                 // Always show connection issue messages regardless of queue status
                 if (playerManager.hasConnectionIssue(player)) {
@@ -326,6 +327,8 @@ public class VelocityLimboHandler {
     }
 
     private static void reconnectPlayer(Player player) {
+        if (!config.getBoolean(Route.from("enable-sending-back"))) return;
+
         if (player == null || !player.isActive()) return;
         if (authManager.isAuthBlocked(player)) return;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,9 @@ file-version: 5
 # The name of the limbo server in your velocity network
 limbo-name: limbo # Default "limbo"
 
+# Should players be sent back to the server they last connected to automatically?
+enable-sending-back: true
+
 # Direct-connect-server is the name of the server you want players to connect to if they connected directly to the server in the velocity network
 direct-connect-server: lobby # Default "lobby"
 
@@ -17,5 +20,5 @@ queue-notify-interval: 30 # The time in seconds (Default: 30)
 # A list of disabled commands, which will not work inside the Limbo server. Recommended commands are ones that the player can use to transfer server, like /server or /hub
 disabled-commands: ["server", "lobby", "hub"]
 
-# The time a player has to authenticate, if an Authentication plugin is installed, in seconds
+# The time a player has to authenticate if an Authentication plugin is installed, in seconds
 auth-timeout-seconds: 120 # Default 120


### PR DESCRIPTION
This PR enables server administrators to toggle a configuration value to disable this plugin from automatically sending players back to where they last were.