### PR TITLE
Add Unit Tests for Core Components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,14 @@
                     <releaseProfiles>release</releaseProfiles>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <argLine>-Dnet.bytebuddy.experimental=true</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -267,6 +275,25 @@
             <artifactId>bstats-velocity</artifactId>
             <version>3.0.2</version>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/listeners/ConnectionListenerTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/listeners/ConnectionListenerTest.java
@@ -1,0 +1,175 @@
+package com.akselglyholt.velocityLimboHandler.listeners;
+
+import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
+import com.akselglyholt.velocityLimboHandler.misc.ReconnectBlocker;
+import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
+import com.velocitypowered.api.event.connection.DisconnectEvent;
+import com.velocitypowered.api.event.player.ServerPostConnectEvent;
+import com.velocitypowered.api.event.player.ServerPreConnectEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.ServerConnection;
+import com.velocitypowered.api.proxy.config.ProxyConfig;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.net.InetSocketAddress;
+import java.util.*;
+import java.util.logging.Logger;
+
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.route.Route;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class ConnectionListenerTest {
+
+    private MockedStatic<VelocityLimboHandler> mockedVelocityLimboHandler;
+    private PlayerManager playerManager;
+    private ProxyServer proxyServer;
+    private RegisteredServer limboServer;
+    private RegisteredServer directConnectServer;
+    private ReconnectBlocker reconnectBlocker;
+    private Logger logger;
+    private YamlDocument messageConfig;
+
+    private ConnectionListener connectionListener;
+
+    @BeforeEach
+    void setUp() {
+        mockedVelocityLimboHandler = mockStatic(VelocityLimboHandler.class);
+        playerManager = mock(PlayerManager.class);
+        proxyServer = mock(ProxyServer.class);
+        limboServer = mock(RegisteredServer.class);
+        directConnectServer = mock(RegisteredServer.class);
+        reconnectBlocker = mock(ReconnectBlocker.class);
+        logger = mock(Logger.class);
+        messageConfig = mock(YamlDocument.class);
+
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getPlayerManager).thenReturn(playerManager);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getProxyServer).thenReturn(proxyServer);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getLimboServer).thenReturn(limboServer);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getDirectConnectServer).thenReturn(directConnectServer);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getReconnectBlocker).thenReturn(reconnectBlocker);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getLogger).thenReturn(logger);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getMessageConfig).thenReturn(messageConfig);
+
+        when(messageConfig.getString(any(Route.class))).thenReturn("Welcome!");
+
+        // Setup server names
+        ServerInfo limboInfo = mock(ServerInfo.class);
+        when(limboInfo.getName()).thenReturn("limbo");
+        when(limboServer.getServerInfo()).thenReturn(limboInfo);
+
+        ServerInfo directInfo = mock(ServerInfo.class);
+        when(directInfo.getName()).thenReturn("hub");
+        when(directConnectServer.getServerInfo()).thenReturn(directInfo);
+
+        connectionListener = new ConnectionListener();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedVelocityLimboHandler.close();
+    }
+
+    @Test
+    void testOnPlayerPreConnect_RerouteToLimbo() {
+        ServerPreConnectEvent event = mock(ServerPreConnectEvent.class);
+        Player player = mock(Player.class);
+        RegisteredServer intendedServer = mock(RegisteredServer.class);
+        ServerInfo intendedInfo = mock(ServerInfo.class);
+
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getOriginalServer()).thenReturn(intendedServer);
+        when(intendedServer.getServerInfo()).thenReturn(intendedInfo);
+        when(intendedInfo.getName()).thenReturn("survival");
+
+        when(playerManager.isPlayerConnecting(player)).thenReturn(false);
+        when(playerManager.hasQueuedPlayers(intendedServer)).thenReturn(true);
+
+        connectionListener.onPlayerPreConnect(event);
+
+        verify(event).setResult(argThat(result -> 
+            result.getServer().isPresent() && result.getServer().get().equals(limboServer)
+        ));
+    }
+
+    @Test
+    void testOnPlayerPreConnect_NoRerouteIfAlreadyLimbo() {
+        ServerPreConnectEvent event = mock(ServerPreConnectEvent.class);
+        Player player = mock(Player.class);
+        RegisteredServer intendedServer = mock(RegisteredServer.class);
+        ServerInfo intendedInfo = mock(ServerInfo.class);
+
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getOriginalServer()).thenReturn(intendedServer);
+        when(intendedServer.getServerInfo()).thenReturn(intendedInfo);
+        when(intendedInfo.getName()).thenReturn("limbo");
+
+        connectionListener.onPlayerPreConnect(event);
+
+        verify(event, never()).setResult(any());
+    }
+
+    @Test
+    void testOnPlayerPostConnect_JoinedLimbo() {
+        ServerPostConnectEvent event = mock(ServerPostConnectEvent.class);
+        Player player = mock(Player.class);
+        ServerConnection serverConnection = mock(ServerConnection.class);
+
+        when(event.getPlayer()).thenReturn(player);
+        when(player.getCurrentServer()).thenReturn(Optional.of(serverConnection));
+        when(serverConnection.getServer()).thenReturn(limboServer);
+        when(event.getPreviousServer()).thenReturn(null);
+
+        // Mock VirtualHost
+        when(player.getVirtualHost()).thenReturn(Optional.empty());
+
+        connectionListener.onPlayerPostConnect(event);
+
+        // Should be added to player manager targeting directConnectServer (since no previous server and no virtual host)
+        verify(playerManager).addPlayer(player, directConnectServer);
+    }
+    
+    @Test
+    void testOnPlayerPostConnect_LeftLimbo() {
+        ServerPostConnectEvent event = mock(ServerPostConnectEvent.class);
+        Player player = mock(Player.class);
+        ServerConnection serverConnection = mock(ServerConnection.class);
+        RegisteredServer currentServer = mock(RegisteredServer.class);
+        ServerInfo currentInfo = mock(ServerInfo.class);
+
+        when(event.getPlayer()).thenReturn(player);
+        when(player.getCurrentServer()).thenReturn(Optional.of(serverConnection));
+        when(serverConnection.getServer()).thenReturn(currentServer);
+        when(currentServer.getServerInfo()).thenReturn(currentInfo);
+        when(currentInfo.getName()).thenReturn("hub");
+        
+        when(event.getPreviousServer()).thenReturn(limboServer);
+
+        connectionListener.onPlayerPostConnect(event);
+
+        verify(playerManager).removePlayer(player);
+    }
+
+    @Test
+    void testOnDisconnect() {
+        DisconnectEvent event = mock(DisconnectEvent.class);
+        Player player = mock(Player.class);
+        UUID uuid = UUID.randomUUID();
+
+        when(event.getPlayer()).thenReturn(player);
+        when(player.getUniqueId()).thenReturn(uuid);
+
+        connectionListener.onDisconnect(event);
+
+        verify(playerManager).removePlayer(player);
+        verify(playerManager).removePlayerIssue(player);
+        verify(reconnectBlocker).unblock(uuid);
+    }
+}

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/misc/UtilityTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/misc/UtilityTest.java
@@ -1,0 +1,86 @@
+package com.akselglyholt.velocityLimboHandler.misc;
+
+import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.route.Route;
+import static org.mockito.Mockito.*;
+
+class UtilityTest {
+
+    private MockedStatic<VelocityLimboHandler> mockedVelocityLimboHandler;
+    private ProxyServer proxyServer;
+    private Logger logger;
+    private YamlDocument messageConfig;
+
+    @BeforeEach
+    void setUp() {
+        mockedVelocityLimboHandler = mockStatic(VelocityLimboHandler.class);
+        proxyServer = mock(ProxyServer.class);
+        logger = mock(Logger.class);
+        messageConfig = mock(YamlDocument.class);
+
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getProxyServer).thenReturn(proxyServer);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getLogger).thenReturn(logger);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getMessageConfig).thenReturn(messageConfig);
+        
+        when(messageConfig.getString(any(Route.class))).thenReturn("Welcome!");
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedVelocityLimboHandler.close();
+    }
+
+    @Test
+    void testDoServerNamesMatch() {
+        RegisteredServer server1 = mock(RegisteredServer.class);
+        RegisteredServer server2 = mock(RegisteredServer.class);
+        ServerInfo info1 = mock(ServerInfo.class);
+        ServerInfo info2 = mock(ServerInfo.class);
+
+        when(server1.getServerInfo()).thenReturn(info1);
+        when(server2.getServerInfo()).thenReturn(info2);
+        when(info1.getName()).thenReturn("limbo");
+        when(info2.getName()).thenReturn("limbo");
+
+        assertTrue(Utility.doServerNamesMatch(server1, server2));
+
+        when(info2.getName()).thenReturn("lobby");
+        assertFalse(Utility.doServerNamesMatch(server1, server2));
+    }
+
+    @Test
+    void testGetServerByName_Found() {
+        String serverName = "limbo";
+        RegisteredServer server = mock(RegisteredServer.class);
+        when(proxyServer.getServer(serverName)).thenReturn(Optional.of(server));
+
+        RegisteredServer result = Utility.getServerByName(serverName);
+
+        assertNotNull(result);
+        assertEquals(server, result);
+    }
+
+    @Test
+    void testGetServerByName_NotFound() {
+        String serverName = "invalid";
+        when(proxyServer.getServer(serverName)).thenReturn(Optional.empty());
+
+        RegisteredServer result = Utility.getServerByName(serverName);
+
+        assertNull(result);
+        verify(logger).severe(contains("is invalid"));
+    }
+}

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManagerTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManagerTest.java
@@ -1,0 +1,133 @@
+package com.akselglyholt.velocityLimboHandler.storage;
+
+import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
+import com.akselglyholt.velocityLimboHandler.auth.AuthManager;
+import com.akselglyholt.velocityLimboHandler.misc.ReconnectBlocker;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.route.Route;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PlayerManagerTest {
+
+    private MockedStatic<VelocityLimboHandler> mockedVelocityLimboHandler;
+    private AuthManager authManager;
+    private ReconnectBlocker reconnectBlocker;
+    private ProxyServer proxyServer;
+    private YamlDocument messageConfig;
+    private RegisteredServer directConnectServer;
+    private Logger logger;
+
+    private PlayerManager playerManager;
+
+    @BeforeEach
+    void setUp() {
+        mockedVelocityLimboHandler = mockStatic(VelocityLimboHandler.class);
+        authManager = mock(AuthManager.class);
+        reconnectBlocker = mock(ReconnectBlocker.class);
+        proxyServer = mock(ProxyServer.class);
+        messageConfig = mock(YamlDocument.class);
+        directConnectServer = mock(RegisteredServer.class);
+        logger = mock(Logger.class);
+
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getAuthManager).thenReturn(authManager);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getReconnectBlocker).thenReturn(reconnectBlocker);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getProxyServer).thenReturn(proxyServer);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getMessageConfig).thenReturn(messageConfig);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getDirectConnectServer).thenReturn(directConnectServer);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getLogger).thenReturn(logger);
+        
+        // Default behavior
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::isQueueEnabled).thenReturn(true);
+        when(messageConfig.getString(any(Route.class))).thenReturn("Queue Position: %position%");
+        
+        ServerInfo directInfo = mock(ServerInfo.class);
+        when(directInfo.getName()).thenReturn("hub");
+        when(directConnectServer.getServerInfo()).thenReturn(directInfo);
+
+        playerManager = new PlayerManager();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedVelocityLimboHandler.close();
+    }
+
+    @Test
+    void testAddPlayer() {
+        Player player = mock(Player.class);
+        RegisteredServer server = mock(RegisteredServer.class);
+        ServerInfo info = mock(ServerInfo.class);
+
+        when(server.getServerInfo()).thenReturn(info);
+        when(info.getName()).thenReturn("survival");
+        
+        // Stub proxyServer to return the server
+        when(proxyServer.getServer("survival")).thenReturn(Optional.of(server));
+
+        playerManager.addPlayer(player, server);
+
+        assertTrue(playerManager.isPlayerRegistered(player));
+        assertEquals(server, playerManager.getPreviousServer(player));
+    }
+
+    @Test
+    void testRemovePlayer() {
+        Player player = mock(Player.class);
+        RegisteredServer server = mock(RegisteredServer.class);
+        ServerInfo info = mock(ServerInfo.class);
+        UUID uuid = UUID.randomUUID();
+
+        when(player.getUniqueId()).thenReturn(uuid);
+        when(server.getServerInfo()).thenReturn(info);
+        when(info.getName()).thenReturn("survival");
+
+        playerManager.addPlayer(player, server);
+        assertTrue(playerManager.isPlayerRegistered(player));
+
+        playerManager.removePlayer(player);
+
+        assertFalse(playerManager.isPlayerRegistered(player));
+        verify(reconnectBlocker).unblock(uuid);
+    }
+
+    @Test
+    void testQueueLogic() {
+        Player player1 = mock(Player.class);
+        Player player2 = mock(Player.class);
+        RegisteredServer server = mock(RegisteredServer.class);
+        ServerInfo info = mock(ServerInfo.class);
+
+        when(server.getServerInfo()).thenReturn(info);
+        when(info.getName()).thenReturn("survival");
+
+        playerManager.addPlayer(player1, server);
+        playerManager.addPlayer(player2, server); // Implicitly adds to queue if queue enabled
+
+        assertTrue(playerManager.hasQueuedPlayers(server));
+        
+        // Verify queue order
+        assertEquals(player1, playerManager.getNextQueuedPlayer(server));
+        
+        // getNextQueuedPlayer acts as peek, doesn't remove
+        assertEquals(player1, playerManager.getNextQueuedPlayer(server)); 
+        
+        // Remove player 1
+        playerManager.removePlayerFromQueue(player1);
+        
+        assertEquals(player2, playerManager.getNextQueuedPlayer(server));
+    }
+}


### PR DESCRIPTION
This PR implements unit tests for key components of the `velocity-limbo-handler` plugin to improve code reliability and prevent regressions. It establishes a testing infrastructure using JUnit 5 and Mockito.

## Changes
- **Dependencies**: Added `junit-jupiter`, `mockito-junit-jupiter`, and `mockito-inline` to `pom.xml`.
- **Configuration**: Updated `maven-surefire-plugin` with `-Dnet.bytebuddy.experimental=true` to enable support for running tests on Java 23+ environments (while maintaining compatibility with Java 17).
- **New Tests**:
  - `UtilityTest`: Verifies helper methods like `doServerNamesMatch` and `getServerByName`.
  - `ConnectionListenerTest`: Tests `onPlayerPreConnect` (rerouting logic), `onPlayerPostConnect`, and `onDisconnect`.
  - `PlayerManagerTest`: Covers player tracking, queue management logic, and state cleanup.

## Verification
Run the tests using Maven:
```bash
mvn test
```

## Implementation Details
- **Static Mocking**: Extensive use of `mockito-inline` (`mockStatic`) was implemented to handle the heavy reliance on static state in `VelocityLimboHandler` and `Utility` classes.
- **Isolation**: The tests mock the Velocity `ProxyServer`, `Logger`, and internal `YamlDocument` configuration to run completely in isolation without requiring a running Velocity proxy instance.
