### PR TITLE
Extended placeholders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akselglyholt</groupId>
     <artifactId>velocity-limbo-handler</artifactId>
-    <version>1.8.2</version>
+    <version>1.8.3</version>
     <packaging>jar</packaging>
 
     <name>velocity-limbo-handler</name>

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/MessageFormatter.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/MessageFormatter.java
@@ -2,19 +2,42 @@ package com.akselglyholt.velocityLimboHandler.misc;
 
 import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
 
 public class MessageFormatter {
     public static String formatMessage(String msg, Player player) {
-        return formatMessage(msg, player, null);
-    }
+        RegisteredServer server = null;
 
-    public static String formatMessage(String msg, Player player, Integer queuePosition) {
+        if (msg.contains("[player]")) {
+            msg = msg.replace("[player]", player.getUsername());
+        }
+
         if (msg.contains("[queue-position]")) {
-            int position = queuePosition != null
-                    ? queuePosition
-                    : VelocityLimboHandler.getPlayerManager().getQueuePosition(player);
-
+            int position = VelocityLimboHandler.getPlayerManager().getQueuePosition(player);
             msg = msg.replace("[queue-position]", Integer.toString(position));
+        }
+
+        if (msg.contains("[queue-size]")) {
+            if (server == null) {
+                server = VelocityLimboHandler.getPlayerManager().getPreviousServer(player);
+            }
+
+            int size = VelocityLimboHandler.getPlayerManager().getQueueForServer(server.getServerInfo().getName()).size();
+            msg = msg.replace("[queue-size]", Integer.toString(size));
+        }
+
+        if (msg.contains("[total-limbo]")) {
+            int size = VelocityLimboHandler.getLimboServer().getPlayersConnected().size();
+            msg = msg.replace("[total-limbo]", Integer.toString(size));
+        }
+
+        if (msg.contains("[queued-server]")) {
+            if (server == null) {
+                server = VelocityLimboHandler.getPlayerManager().getPreviousServer(player);
+            }
+
+            String serverName = server.getServerInfo().getName();
+            msg = msg.replace("[queued-server]", serverName);
         }
 
         return msg;

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/QueueNotifierTask.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/QueueNotifierTask.java
@@ -53,7 +53,7 @@ public class QueueNotifierTask implements Runnable {
 
             int position = playerManager.getQueuePosition(player);
             if (position == -1) continue;
-            String formatedQueuePositionMsg = MessageFormatter.formatMessage(configManager.getQueuePositionMsg(), player, position);
+            String formatedQueuePositionMsg = MessageFormatter.formatMessage(configManager.getQueuePositionMsg(), player);
 
             player.sendMessage(miniMessage.deserialize(formatedQueuePositionMsg));
         }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,10 +1,14 @@
-file-version: 3
+file-version: 4
 
 # You can change all messages inside this file.
 # Messages use minimessage format: https://docs.advntr.dev/minimessage/index.html
 
 # Messages can include placeholders such as:
+# [player] player username
 # [queue-position] which will display queue position
+# [queue-size] size of the queue
+# [total-limbo] total players in the limbo
+# [queued-server] displays the server that the player is in queue for
 
 # These messages are for errors under reconnection, such as not whitelisted or banned.
 bannedMessage: "<red>⛔ You are banned from that server.</red>"

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/misc/MessageFormatterTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/misc/MessageFormatterTest.java
@@ -1,0 +1,93 @@
+package com.akselglyholt.velocityLimboHandler.misc;
+
+import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
+import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class MessageFormatterTest {
+
+    private MockedStatic<VelocityLimboHandler> mockedVelocityLimboHandler;
+    private PlayerManager playerManager;
+    private Player player;
+    private RegisteredServer previousServer;
+    private RegisteredServer limboServer;
+    private ServerInfo serverInfo;
+
+    @BeforeEach
+    void setUp() {
+        mockedVelocityLimboHandler = mockStatic(VelocityLimboHandler.class);
+        playerManager = mock(PlayerManager.class);
+        player = mock(Player.class);
+        previousServer = mock(RegisteredServer.class);
+        limboServer = mock(RegisteredServer.class);
+        serverInfo = mock(ServerInfo.class);
+
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getPlayerManager).thenReturn(playerManager);
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getLimboServer).thenReturn(limboServer);
+
+        when(player.getUsername()).thenReturn("Aksel");
+        when(playerManager.getQueuePosition(player)).thenReturn(4);
+        when(playerManager.getPreviousServer(player)).thenReturn(previousServer);
+        when(playerManager.getQueueForServer("survival")).thenReturn(List.of(
+                new PlayerManager.QueuedPlayer(UUID.randomUUID(), "Alpha"),
+                new PlayerManager.QueuedPlayer(UUID.randomUUID(), "Bravo"),
+                new PlayerManager.QueuedPlayer(UUID.randomUUID(), "Charlie")
+        ));
+        when(previousServer.getServerInfo()).thenReturn(serverInfo);
+        when(serverInfo.getName()).thenReturn("survival");
+        when(limboServer.getPlayersConnected()).thenReturn(List.of(player, mock(Player.class)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedVelocityLimboHandler.close();
+    }
+
+    @Test
+    void testFormatMessage_ReplacesAllSupportedPlaceholders() {
+        String result = MessageFormatter.formatMessage(
+                "[player] is #[queue-position] of [queue-size] for [queued-server] with [total-limbo] in limbo",
+                player
+        );
+
+        assertEquals("Aksel is #4 of 3 for survival with 2 in limbo", result);
+        verify(playerManager).getQueuePosition(player);
+        verify(playerManager).getQueueForServer("survival");
+        verify(playerManager, times(1)).getPreviousServer(player);
+    }
+
+    @Test
+    void testFormatMessage_ReusesPreviousServerAcrossServerPlaceholders() {
+        String result = MessageFormatter.formatMessage("[queue-size] players waiting for [queued-server]", player);
+
+        assertEquals("3 players waiting for survival", result);
+        verify(playerManager, times(1)).getPreviousServer(player);
+    }
+
+    @Test
+    void testFormatMessage_LeavesMessageUntouchedWhenNoPlaceholdersExist() {
+        String message = "Nothing to replace here";
+
+        String result = MessageFormatter.formatMessage(message, player);
+
+        assertEquals(message, result);
+        verifyNoInteractions(playerManager, limboServer, previousServer, serverInfo);
+    }
+}


### PR DESCRIPTION
Added following message templates:
- `[player|`: Player username
- `[queue-position|`: Players position in queue
- `[queue-size|`: Size of the queue, that the player current is in
- `[total-limbo|`: Total amount of players on the limbo server
- `[queued-server|`: Server of which the player is currently queued up for