### PR TITLE
Toggleable connection warnings

### DIFF
--- a/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
@@ -35,6 +35,7 @@ public class ConfigManager {
     private int queueNotifyInterval;
     private boolean queueEnabled;
     private List<String> disabledCommands;
+    private boolean connectionWarnings;
 
     public ConfigManager(Path dataDirectory, Logger logger) {
         this.dataDirectory = dataDirectory;
@@ -83,6 +84,7 @@ public class ConfigManager {
         queueNotifyInterval = config.getInt(Route.from("queue-notify-interval"));
         queueEnabled = config.getBoolean(Route.from("queue-enabled"), true);
         disabledCommands = config.getStringList("disabled-commands");
+        connectionWarnings = config.getBoolean("connection-warnings", false);
     }
 
     public YamlDocument getConfig() {
@@ -139,5 +141,9 @@ public class ConfigManager {
 
     public List<String> getDisabledCommands() {
         return disabledCommands;
+    }
+
+    public boolean isConnectionWarningsEnabled() {
+        return connectionWarnings;
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
@@ -90,10 +90,12 @@ public class ReconnectHandler {
 
                 if (result.getStatus() == ConnectionRequestBuilder.Status.CONNECTION_IN_PROGRESS) return;
 
-                Utility.logInformational(String.format("Connection failed for %s to %s. Result status: %s",
-                        player.getUsername(),
-                        previousServer.getServerInfo().getName(),
-                        result.getStatus()));
+                if (configManager.isConnectionWarningsEnabled()) {
+                    Utility.logInformational(String.format("Connection failed for %s to %s. Result status: %s",
+                            player.getUsername(),
+                            previousServer.getServerInfo().getName(),
+                            result.getStatus()));
+                }
 
                 if (connectionThrowable != null) {
                     // Get the error message from throwable

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-file-version: 6
+file-version: 7
 
 # Server configs - These are settings you need to change!
 # The name of the limbo server in your velocity network
@@ -16,3 +16,6 @@ queue-notify-interval: 30 # The time in seconds (Default: 30)
 
 # A list of disabled commands, which will not work inside the Limbo server. Recommended commands are ones that the player can use to transfer server, like /server or /hub
 disabled-commands: ["server", "lobby", "hub"]
+
+# Debug/information
+connection-warnings: false # Should connection failures/warnings be logged (Default: false)


### PR DESCRIPTION
There is a new config option in `config.yaml`, which allows the user to disable the logging of connection warnings. Useful for if another plugin cancels a connection, it won't flood the console.

Defaults to false