### PR TITLE
Refactor disconnect reason handling to use component inspection

### DIFF
--- a/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
@@ -10,6 +10,8 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerPing;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 
@@ -95,37 +97,22 @@ public class ReconnectHandler {
                         previousServer.getServerInfo().getName(),
                         result.getStatus()));
 
-                if (connectionThrowable != null) {
-                    // Get the error message from throwable
-                    String errorMessage = connectionThrowable.getMessage();
-                    if (errorMessage == null) errorMessage = "";
-
-                    // Also check the result component if available
-                    String reasonFromComponent = "";
-                    if (result.getReasonComponent().isPresent()) {
-                        reasonFromComponent = PlainTextComponentSerializer.plainText().serialize(result.getReasonComponent().get());
+                if (result.getStatus() == ConnectionRequestBuilder.Status.SERVER_DISCONNECTED) {
+                    Optional<Component> reasonOpt = result.getReasonComponent();
+                    if (reasonOpt.isPresent()) {
+                        Component reason = reasonOpt.get();
+                        if (!playerConnectIssue(player, reason)) {
+                            String plainReason = PlainTextComponentSerializer.plainText().serialize(reason);
+                            player.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + plainReason + "</red>"));
+                        }
                     }
+                    return;
+                }
 
-                    // Check both the throwable message and the component reason
-                    String combinedErrorMessage = (errorMessage + " " + reasonFromComponent).toLowerCase();
-
-                    // Notify user of their issue, and them to issue list
-                    if (playerConnectIssue(player, combinedErrorMessage)) return;
-
-                    // Handle any other connection errors
-                    player.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + (errorMessage.isEmpty() ? reasonFromComponent : errorMessage) + "</red>"));
-                } else {
-                    // Handle case where we have a result but no throwable
-                    Optional<Component> reasonComponent = result.getReasonComponent();
-
-                    if (reasonComponent.isPresent()) {
-                        String reason = PlainTextComponentSerializer.plainText().serialize(reasonComponent.get()).toLowerCase();
-
-                        // Notify user of their issue, and them to issue list
-                        if (playerConnectIssue(player, reason)) return;
-
-                        // Handle any other connection errors
-                        player.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + reason + "</red>"));
+                if (connectionThrowable != null) {
+                    String errorMessage = connectionThrowable.getMessage();
+                    if (errorMessage != null && !errorMessage.isEmpty()) {
+                        player.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + errorMessage + "</red>"));
                     }
                 }
             }));
@@ -134,29 +121,26 @@ public class ReconnectHandler {
         return true;
     }
 
-    private boolean playerConnectIssue(Player player, String reason) {
-        if (reason.contains("ban") || reason.contains("banned")) {
-            String formattedMsg = MessageFormatter.formatMessage(configManager.getBannedMsg(), player);
-
-            player.sendMessage(miniMessage.deserialize(formattedMsg));
-
-            // Mark them with an issue instead of kicking
-            playerManager.addPlayerWithIssue(player, "banned");
-
-            // Remove them from the reconnection queue to avoid blocking others
-            playerManager.removePlayerFromQueue(player);
-            return true;
+    private boolean playerConnectIssue(Player player, Component reason) {
+        if (reason instanceof TranslatableComponent translatable) {
+            String key = translatable.key();
+            if (key.contains("banned")) {
+                player.sendMessage(miniMessage.deserialize(MessageFormatter.formatMessage(configManager.getBannedMsg(), player)));
+                playerManager.addPlayerWithIssue(player, "banned");
+                playerManager.removePlayerFromQueue(player);
+                return true;
+            }
+            if (key.contains("not_whitelisted")) {
+                player.sendMessage(miniMessage.deserialize(MessageFormatter.formatMessage(configManager.getWhitelistedMsg(), player)));
+                playerManager.addPlayerWithIssue(player, "not_whitelisted");
+                playerManager.removePlayerFromQueue(player);
+                return true;
+            }
         }
 
-        if (reason.contains("whitelist") || reason.contains("not whitelisted")) {
-            String formattedMsg = MessageFormatter.formatMessage(configManager.getWhitelistedMsg(), player);
-
-            player.sendMessage(miniMessage.deserialize(formattedMsg));
-
-            // Mark them with an issue instead of kicking
+        if (reason instanceof TextComponent textComponent && textComponent.content().toLowerCase().contains("whitelist")) {
+            player.sendMessage(miniMessage.deserialize(MessageFormatter.formatMessage(configManager.getWhitelistedMsg(), player)));
             playerManager.addPlayerWithIssue(player, "not_whitelisted");
-
-            // Remove them from the reconnection queue to avoid blocking others
             playerManager.removePlayerFromQueue(player);
             return true;
         }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
@@ -12,9 +12,12 @@ import com.velocitypowered.api.proxy.server.ServerPing;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.TranslationArgument;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -121,11 +124,27 @@ public class ReconnectHandler {
         return true;
     }
 
+    private Optional<Component> extractBanReason(TranslatableComponent component) {
+        List<TranslationArgument> args = component.arguments();
+        if (args.isEmpty()) return Optional.empty();
+        Component reasonComponent = args.get(0).asComponent();
+        if (reasonComponent instanceof TranslatableComponent) return Optional.empty();
+        String plain = PlainTextComponentSerializer.plainText().serialize(reasonComponent).trim();
+        return plain.isEmpty() ? Optional.empty() : Optional.of(reasonComponent);
+    }
+
     private boolean playerConnectIssue(Player player, Component reason) {
         if (reason instanceof TranslatableComponent translatable) {
             String key = translatable.key();
             if (key.contains("banned")) {
-                player.sendMessage(miniMessage.deserialize(MessageFormatter.formatMessage(configManager.getBannedMsg(), player)));
+                Component message = miniMessage.deserialize(MessageFormatter.formatMessage(configManager.getBannedMsg(), player));
+                Optional<Component> banReason = extractBanReason(translatable);
+                if (banReason.isPresent()) {
+                    message = message.append(Component.newline())
+                            .append(Component.text("Reason: ", NamedTextColor.GRAY))
+                            .append(banReason.get());
+                }
+                player.sendMessage(message);
                 playerManager.addPlayerWithIssue(player, "banned");
                 playerManager.removePlayerFromQueue(player);
                 return true;


### PR DESCRIPTION
Previously, playerConnectIssue serialized the disconnect reason component to a plain text string and searched for keywords like "ban" or "whitelist". This is fragile — a ban plugin using custom message text (e.g. in a different language, or just a phrase that doesn't contain "ban") would silently fall through and never be classified correctly.

This PR replaces that approach with direct inspection of the ConnectionRequestBuilder.Result component.

## Changes  
- SERVER_DISCONNECTED status is now the single entry point for ban/whitelist detection. Bans and whitelist rejections are server-initiated disconnects; they never arrive via a Java throwable. The old code checked both paths
  redundantly.
  - playerConnectIssue now accepts Component instead of a serialized string. Ban and whitelist detection uses Adventure's component type system:
    - TranslatableComponent with key containing "banned" → ban (covers multiplayer.disconnect.banned, multiplayer.disconnect.banned.reason, multiplayer.disconnect.banned_ip.reason)
    - TranslatableComponent with key containing "not_whitelisted" → whitelist (vanilla)
    - TextComponent content containing "whitelist" → whitelist fallback for servers sending custom plain-text rejection messages
  - Ban reason is now displayed to the player. The multiplayer.disconnect.banned.reason component carries the ban reason as a translation argument. If that argument is a concrete component (i.e. a custom reason was specified
  via /ban player <reason> or a ban plugin), it is extracted and appended below the configured ban message with its original formatting preserved. If no custom reason was given (vanilla default), nothing extra is shown.


##  Why component inspection is more reliable
multiplayer.disconnect.banned.reason arrives as a TranslatableComponent — the key is always "multiplayer.disconnect.banned.reason" regardless of what language or custom text the server uses. Matching on the key is an exact contract with the protocol, not a guess about what words might appear in the rendered string.
