### PR TITLE
Optimize queue processing and runtime resource usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,9 +51,14 @@ Made to work with [LOOHP's Limbo](https://github.com/LOOHP/Limbo) server, but an
 limbo-name: "limbo"                  # The name of your limbo server
 direct-connect-server: "lobby"       # Where to send direct connections
 task-interval: 3000                  # Queue processing interval (milliseconds)
+reconnect-batch-size: 8              # Maximum backend queues checked per processing run
 queue-notify-interval: 30            # How often to tell players their position
+queue-notify-batch-size: 64          # Maximum due notifications sent per dispatcher tick
 disabled-commands: ["server","hub"]  # Commands blocked in limbo
 ```
+
+The batch limits smooth work across scheduler ticks. Increase them for faster catch-up on very large
+networks, or lower them to cap short CPU bursts on constrained proxies.
 
 👉 Messages can be tweaked in `messages.yml` so your players see exactly what you want.
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -141,6 +141,7 @@ public class VelocityLimboHandler {
 
     @Subscribe
     public void onShutdown(ProxyShutdownEvent event) {
+        cancelScheduledTasks();
         if (bstatsMetrics != null) bstatsMetrics.shutdown();
         if (reconnectHandler != null) reconnectHandler.close();
         if (authManager != null) authManager.close();
@@ -148,15 +149,7 @@ public class VelocityLimboHandler {
     }
 
     public synchronized void reloadTasks() {
-        if (reconnectionTask != null) {
-            reconnectionTask.cancel();
-            reconnectionTask = null;
-        }
-
-        if (queueNotifierTask != null) {
-            queueNotifierTask.cancel();
-            queueNotifierTask = null;
-        }
+        cancelScheduledTasks();
 
         String limboName = configManager.getLimboName();
         String directConnectName = configManager.getDirectConnectServerName();
@@ -175,6 +168,18 @@ public class VelocityLimboHandler {
                 .buildTask(this, new QueueNotifierTask(proxyServer, limboServer, playerManager, configManager))
                 .repeat(1, TimeUnit.SECONDS)
                 .schedule();
+    }
+
+    private synchronized void cancelScheduledTasks() {
+        if (reconnectionTask != null) {
+            reconnectionTask.cancel();
+            reconnectionTask = null;
+        }
+
+        if (queueNotifierTask != null) {
+            queueNotifierTask.cancel();
+            queueNotifierTask = null;
+        }
     }
 
     public synchronized void applyReloadedConfiguration() {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -135,10 +135,7 @@ public class VelocityLimboHandler {
         getLogger().info("Queue Enabled: " + configManager.isQueueEnabled());
 
         // Disabled commands
-        List<String> disabledCommands = configManager.getDisabledCommands();
-        for (String cmd : disabledCommands) {
-            commandBlocker.blockCommand(cmd, CommandBlockRule.onServer(limboName));
-        }
+        commandBlocker.replaceCommands(configManager.getDisabledCommands(), CommandBlockRule.onServer(limboName));
 
         reloadTasks();
     }
@@ -178,6 +175,15 @@ public class VelocityLimboHandler {
                 .buildTask(this, new QueueNotifierTask(proxyServer, limboServer, playerManager, configManager))
                 .repeat(1, TimeUnit.SECONDS)
                 .schedule();
+    }
+
+    public synchronized void applyReloadedConfiguration() {
+        playerManager.reloadMessages();
+        commandBlocker.replaceCommands(
+                configManager.getDisabledCommands(),
+                CommandBlockRule.onServer(configManager.getLimboName())
+        );
+        reloadTasks();
     }
 
     private void initializeMaintenanceIntegration() {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @Plugin(id = "velocity-limbo-handler", name = "VelocityLimboHandler", authors = "Aksel Glyholt", version = VersionInfo.VERSION, dependencies = {
@@ -80,10 +81,8 @@ public class VelocityLimboHandler {
         try {
             configManager.load();
         } catch (IOException e) {
-            logger.severe("Something went wrong while trying to update/create config: " + e);
-            logger.severe("Plugin will now shut down!");
-            Optional<PluginContainer> container = proxyServer.getPluginManager().getPlugin("velocity-limbo-handler");
-            container.ifPresent(pluginContainer -> pluginContainer.getExecutorService().shutdown());
+            logger.log(Level.SEVERE, "Unable to load VelocityLimboHandler configuration", e);
+            throw new IllegalStateException("VelocityLimboHandler cannot start without a valid configuration", e);
         }
 
         playerManager = new PlayerManager();

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -144,6 +144,7 @@ public class VelocityLimboHandler {
     public void onShutdown(ProxyShutdownEvent event) {
         if (bstatsMetrics != null) bstatsMetrics.shutdown();
         if (reconnectHandler != null) reconnectHandler.close();
+        if (authManager != null) authManager.close();
         Utility.clearMaintenanceAdapter();
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -174,7 +174,10 @@ public class VelocityLimboHandler {
 
         reconnectionTask = proxyServer.getScheduler().buildTask(this, new ReconnectionTask(proxyServer, limboServer, playerManager, authManager, configManager, reconnectHandler)).repeat(configManager.getTaskInterval(), TimeUnit.MILLISECONDS).schedule();
 
-        queueNotifierTask = proxyServer.getScheduler().buildTask(this, new QueueNotifierTask(limboServer, playerManager, configManager)).repeat(configManager.getQueueNotifyInterval(), TimeUnit.SECONDS).schedule();
+        queueNotifierTask = proxyServer.getScheduler()
+                .buildTask(this, new QueueNotifierTask(proxyServer, limboServer, playerManager, configManager))
+                .repeat(1, TimeUnit.SECONDS)
+                .schedule();
     }
 
     private void initializeMaintenanceIntegration() {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -146,6 +146,7 @@ public class VelocityLimboHandler {
     @Subscribe
     public void onShutdown(ProxyShutdownEvent event) {
         if (bstatsMetrics != null) bstatsMetrics.shutdown();
+        Utility.clearMaintenanceAdapter();
     }
 
     public synchronized void reloadTasks() {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -96,22 +96,6 @@ public class VelocityLimboHandler {
 
     @Subscribe
     public void onInitialize(ProxyInitializeEvent event) {
-        // Initialize Metrics
-        int pluginId = 26682;
-        bstatsMetrics = metricsFactory.make(this, pluginId);
-
-        // Metric for players inside the limbo
-        bstatsMetrics.addCustomChart(new SingleLineChart("players_in_limbo", new Callable<Integer>() {
-            @Override
-            public Integer call() {
-                return limboServer != null ? limboServer.getPlayersConnected().size() : 0;
-            }
-        }));
-
-        // Initialize Managers
-        authManager = new AuthManager(this, proxyServer, reconnectBlocker);
-        reconnectHandler = new ReconnectHandler(playerManager, authManager, configManager, logger);
-
         logger.info("Loading Limbo Handler!");
 
         EventManager eventManger = proxyServer.getEventManager();
@@ -122,11 +106,23 @@ public class VelocityLimboHandler {
         limboServer = Utility.getServerByName(limboName);
         directConnectServer = Utility.getServerByName(directConnectName);
 
-        // If either server is null, "self-destruct"
+        // A server can disappear after constructor-time validation if Velocity's registry changes.
         if (limboServer == null || directConnectServer == null) {
-            eventManger.unregisterListeners(this);
             return;
         }
+
+        // Initialize metrics and managers only after all required runtime dependencies exist.
+        int pluginId = 26682;
+        bstatsMetrics = metricsFactory.make(this, pluginId);
+        bstatsMetrics.addCustomChart(new SingleLineChart("players_in_limbo", new Callable<Integer>() {
+            @Override
+            public Integer call() {
+                return limboServer.getPlayersConnected().size();
+            }
+        }));
+
+        authManager = new AuthManager(this, proxyServer, reconnectBlocker);
+        reconnectHandler = new ReconnectHandler(playerManager, authManager, configManager, logger);
 
         eventManger.register(this, new ConnectionListener());
         eventManger.register(this, new CommandExecuteEventListener(commandBlocker, configManager));

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -79,7 +79,9 @@ public class VelocityLimboHandler {
         // Initialize ConfigManager
         configManager = new ConfigManager(dataDirectory, logger);
         try {
-            configManager.load();
+            configManager.load((limboName, directConnectName) ->
+                    server.getServer(limboName).isPresent() && server.getServer(directConnectName).isPresent()
+            );
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Unable to load VelocityLimboHandler configuration", e);
             throw new IllegalStateException("VelocityLimboHandler cannot start without a valid configuration", e);

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -146,6 +146,7 @@ public class VelocityLimboHandler {
     @Subscribe
     public void onShutdown(ProxyShutdownEvent event) {
         if (bstatsMetrics != null) bstatsMetrics.shutdown();
+        if (reconnectHandler != null) reconnectHandler.close();
         Utility.clearMaintenanceAdapter();
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/AuthManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/AuthManager.java
@@ -9,37 +9,36 @@ import com.velocitypowered.api.event.connection.PostLoginEvent;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public final class AuthManager implements AutoCloseable {
-    private final ProxyServer proxy;
     private final ReconnectBlocker blocker;
-    private final List<AuthHandler> handlers = new ArrayList<>();
-    private AuthHandler active = new NoopHandler();
+    private final AuthHandler active;
 
     public AuthManager(Object plugin, ProxyServer proxy, ReconnectBlocker blocker) {
-        this.proxy = proxy;
         this.blocker = blocker;
-        // order matters if multiple are present
-        handlers.add(new LibreLoginHandler(proxy, blocker));
-        handlers.add(new LibreLoginNextHandler(proxy, blocker));
-        handlers.add(new NLoginHandler(proxy, blocker));
-        // add future handlers here
-        selectActive();
+        active = selectActive(proxy, blocker);
         proxy.getEventManager().register(plugin, PostLoginEvent.class, evt -> {
             Player p = evt.getPlayer();
             active.onPlayerJoin(p);
         });
     }
 
-    private void selectActive() {
-        for (var h : handlers) {
-            if (h.isActive()) {
-                active = h;
-                return;
-            }
+    private AuthHandler selectActive(ProxyServer proxy, ReconnectBlocker blocker) {
+        AuthHandler candidate = new LibreLoginHandler(proxy, blocker);
+        if (candidate.isActive()) {
+            return candidate;
         }
+
+        candidate = new LibreLoginNextHandler(proxy, blocker);
+        if (candidate.isActive()) {
+            return candidate;
+        }
+
+        candidate = new NLoginHandler(proxy, blocker);
+        if (candidate.isActive()) {
+            return candidate;
+        }
+
+        return new NoopHandler();
     }
 
     @Override
@@ -48,6 +47,6 @@ public final class AuthManager implements AutoCloseable {
     }
 
     public boolean isAuthBlocked(Player p) {
-        return this.blocker != null && blocker.isBlocked(p.getUniqueId());
+        return blocker != null && blocker.isBlocked(p.getUniqueId());
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginHandler.java
@@ -3,6 +3,7 @@ package com.akselglyholt.velocityLimboHandler.auth.handlers;
 import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
 import com.akselglyholt.velocityLimboHandler.auth.AuthHandler;
 import com.akselglyholt.velocityLimboHandler.misc.ReconnectBlocker;
+import com.akselglyholt.velocityLimboHandler.misc.Utility;
 import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
@@ -13,7 +14,7 @@ import java.util.logging.Logger;
 public class LibreLoginHandler implements AuthHandler {
     private final ProxyServer proxy;
     private final ReconnectBlocker blocker;
-    private volatile boolean active;
+    private final boolean active;
     private final Logger logger = VelocityLimboHandler.getLogger();
     private final PlayerManager playerManager = VelocityLimboHandler.getPlayerManager();
 
@@ -22,9 +23,9 @@ public class LibreLoginHandler implements AuthHandler {
         this.blocker = blocker;
 
         // Detection by plugin id or class existence
-        this.active = proxy.getPluginManager().getPlugin("librelogin").isPresent()
+        boolean detected = proxy.getPluginManager().getPlugin("librelogin").isPresent()
                 || classPresent("xyz.kyngs.librelogin.api.LibreLoginPlugin");
-        if (active) tryHook();
+        this.active = detected && tryHook();
     }
 
     @Override
@@ -44,7 +45,7 @@ public class LibreLoginHandler implements AuthHandler {
         blocker.block(player.getUniqueId(), "auth");
     }
 
-    private void tryHook() {
+    private boolean tryHook() {
         try {
             logger.info("LibreLogin plugin detected! Integrating now");
 
@@ -53,7 +54,7 @@ public class LibreLoginHandler implements AuthHandler {
             var instanceOpt = containerOpt.flatMap(com.velocitypowered.api.plugin.PluginContainer::getInstance);
             if (instanceOpt.isEmpty()) {
                 logger.warning("LibreLogin plugin instance not available.");
-                return;
+                return false;
             }
             Object bootstrap = instanceOpt.get();
 
@@ -81,7 +82,7 @@ public class LibreLoginHandler implements AuthHandler {
                 try {
                     Player p = extractPlayerFromLibreEvent(event);
                     if (p != null) {
-                        logger.info("Player " + p.getUsername() + " authenticated via LibreLogin — unblocked.");
+                        Utility.logDebug(() -> "Player " + p.getUsername() + " authenticated via LibreLogin — unblocked.");
                         blocker.unblock(p.getUniqueId());
 
                         RegisteredServer server = playerManager.getPreviousServer(p);
@@ -109,8 +110,10 @@ public class LibreLoginHandler implements AuthHandler {
             subscribe.invoke(eventProvider, authType, handler);
 
             logger.info("Subscribed to LibreLogin 'authenticated' event.");
+            return true;
         } catch (Exception e) {
             logger.warning("Failed to integrate with LibreLogin: " + e.getMessage());
+            return false;
         }
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginNextHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/LibreLoginNextHandler.java
@@ -3,6 +3,7 @@ package com.akselglyholt.velocityLimboHandler.auth.handlers;
 import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
 import com.akselglyholt.velocityLimboHandler.auth.AuthHandler;
 import com.akselglyholt.velocityLimboHandler.misc.ReconnectBlocker;
+import com.akselglyholt.velocityLimboHandler.misc.Utility;
 import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
@@ -13,7 +14,7 @@ import java.util.logging.Logger;
 public class LibreLoginNextHandler implements AuthHandler {
     private final ProxyServer proxy;
     private final ReconnectBlocker blocker;
-    private volatile boolean active;
+    private final boolean active;
     private final Logger logger = VelocityLimboHandler.getLogger();
     private final PlayerManager playerManager = VelocityLimboHandler.getPlayerManager();
 
@@ -22,9 +23,8 @@ public class LibreLoginNextHandler implements AuthHandler {
         this.blocker = blocker;
 
         // Detection by plugin id or class existence
-        this.active = proxy.getPluginManager().getPlugin("libreloginnext").isPresent();
-
-        if (active) tryHook();
+        boolean detected = proxy.getPluginManager().getPlugin("libreloginnext").isPresent();
+        this.active = detected && tryHook();
     }
 
     @Override
@@ -44,7 +44,7 @@ public class LibreLoginNextHandler implements AuthHandler {
         blocker.block(player.getUniqueId(), "auth");
     }
 
-    private void tryHook() {
+    private boolean tryHook() {
         try {
             logger.info("LibreLoginNext plugin detected! Integrating now");
 
@@ -53,7 +53,7 @@ public class LibreLoginNextHandler implements AuthHandler {
             var instanceOpt = containerOpt.flatMap(com.velocitypowered.api.plugin.PluginContainer::getInstance);
             if (instanceOpt.isEmpty()) {
                 logger.warning("LibreLoginNext plugin instance not available.");
-                return;
+                return false;
             }
             Object bootstrap = instanceOpt.get();
 
@@ -81,7 +81,7 @@ public class LibreLoginNextHandler implements AuthHandler {
                 try {
                     Player p = extractPlayerFromLibreEvent(event);
                     if (p != null) {
-                        logger.info("Player " + p.getUsername() + " authenticated via LibreLoginNext — unblocked.");
+                        Utility.logDebug(() -> "Player " + p.getUsername() + " authenticated via LibreLoginNext — unblocked.");
                         blocker.unblock(p.getUniqueId());
 
                         RegisteredServer server = playerManager.getPreviousServer(p);
@@ -109,8 +109,10 @@ public class LibreLoginNextHandler implements AuthHandler {
             subscribe.invoke(eventProvider, authType, handler);
 
             logger.info("Subscribed to LibreLoginNext 'authenticated' event.");
+            return true;
         } catch (Exception e) {
             logger.warning("Failed to integrate with LibreLoginNext: " + e.getMessage());
+            return false;
         }
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/NLoginHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/auth/handlers/NLoginHandler.java
@@ -3,6 +3,7 @@ package com.akselglyholt.velocityLimboHandler.auth.handlers;
 import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
 import com.akselglyholt.velocityLimboHandler.auth.AuthHandler;
 import com.akselglyholt.velocityLimboHandler.misc.ReconnectBlocker;
+import com.akselglyholt.velocityLimboHandler.misc.Utility;
 import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.player.ServerPreConnectEvent;
@@ -24,10 +25,9 @@ public class NLoginHandler implements AuthHandler {
         this.proxy = proxy;
         this.blocker = blocker;
 
-        this.active = proxy.getPluginManager().getPlugin("nlogin").isPresent()
+        boolean detected = proxy.getPluginManager().getPlugin("nlogin").isPresent()
                 || classPresent("com.nickuc.login.api.NLoginAPI");
-
-        if (active) tryHook();
+        this.active = detected && tryHook();
     }
 
     @Override
@@ -47,7 +47,7 @@ public class NLoginHandler implements AuthHandler {
         blocker.block(player.getUniqueId(), "auth");
     }
 
-    private void tryHook() {
+    private boolean tryHook() {
         try {
             logger.info("NLogin plugin detected! Integrating now");
 
@@ -57,7 +57,7 @@ public class NLoginHandler implements AuthHandler {
             proxy.getEventManager().register(VelocityLimboHandler.getInstance(), eventClass, event -> {
                 try {
                     Player player = (Player) getPlayer.invoke(event);
-                    logger.info("Player " + player.getUsername() + " authenticated via NLogin — unblocked.");
+                    Utility.logDebug(() -> "Player " + player.getUsername() + " authenticated via NLogin — unblocked.");
 
                     blocker.unblock(player.getUniqueId());
                 } catch (Exception ex) {
@@ -69,9 +69,10 @@ public class NLoginHandler implements AuthHandler {
             proxy.getEventManager().register(VelocityLimboHandler.getInstance(), ServerPreConnectEvent.class, this::onServerPreConnect);
 
             logger.info("Subscribed to NLogin AuthenticateEvent.");
+            return true;
         } catch (Exception e) {
             logger.warning("Failed to integrate with NLogin: " + e.getMessage());
-            e.printStackTrace();
+            return false;
         }
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/commands/CommandBlocker.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/commands/CommandBlocker.java
@@ -1,17 +1,28 @@
 package com.akselglyholt.velocityLimboHandler.commands;
 
 import java.util.HashMap;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Locale;
 
 public class CommandBlocker {
-    private final Map<String, CommandBlockRule> commandRules = new HashMap<>();
+    private volatile Map<String, CommandBlockRule> commandRules = Map.of();
 
-    public void blockCommand(String command, CommandBlockRule rule) {
-        commandRules.put(command.toLowerCase(Locale.ROOT), rule);
+    public synchronized void blockCommand(String command, CommandBlockRule rule) {
+        Map<String, CommandBlockRule> updatedRules = new HashMap<>(commandRules);
+        updatedRules.put(command.toLowerCase(Locale.ROOT), rule);
+        commandRules = Map.copyOf(updatedRules);
     }
 
-    public final Map<String, CommandBlockRule> getCommandRules() {
-        return commandRules;
+    public void replaceCommands(Collection<String> commands, CommandBlockRule rule) {
+        Map<String, CommandBlockRule> updatedRules = new HashMap<>();
+        for (String command : commands) {
+            updatedRules.put(command.toLowerCase(Locale.ROOT), rule);
+        }
+        commandRules = Map.copyOf(updatedRules);
+    }
+
+    public CommandBlockRule getRule(String command) {
+        return commandRules.get(command);
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/commands/CommandBlocker.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/commands/CommandBlocker.java
@@ -2,12 +2,13 @@ package com.akselglyholt.velocityLimboHandler.commands;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Locale;
 
 public class CommandBlocker {
     private final Map<String, CommandBlockRule> commandRules = new HashMap<>();
 
     public void blockCommand(String command, CommandBlockRule rule) {
-        commandRules.put(command.toLowerCase(), rule);
+        commandRules.put(command.toLowerCase(Locale.ROOT), rule);
     }
 
     public final Map<String, CommandBlockRule> getCommandRules() {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/commands/VlhAdminCommand.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/commands/VlhAdminCommand.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class VlhAdminCommand implements SimpleCommand {
     private static final String ADMIN_PERMISSION = "vlh.admin";
@@ -26,6 +27,7 @@ public class VlhAdminCommand implements SimpleCommand {
     private static final int QUEUE_PAGE_SIZE = 10;
 
     private final MiniMessage miniMessage;
+    private final AtomicBoolean reloadInProgress = new AtomicBoolean();
 
     public VlhAdminCommand() {
         this.miniMessage = MiniMessage.miniMessage();
@@ -92,17 +94,25 @@ public class VlhAdminCommand implements SimpleCommand {
             return;
         }
 
-        ConfigManager configManager = VelocityLimboHandler.getConfigManager();
-
-        try {
-            configManager.load();
-            VelocityLimboHandler.getPlayerManager().reloadMessages();
-            VelocityLimboHandler.getInstance().reloadTasks();
-            send(source, "<green>✔ Reload complete.</green> <gray>Configuration, messages, and task schedules were refreshed.</gray>");
-        } catch (IOException exception) {
-            send(source, "<red>✖ Reload failed.</red> <gray>Could not reload configuration. Check console for details.</gray>");
-            VelocityLimboHandler.getLogger().severe("Failed to reload configuration: " + exception.getMessage());
+        if (!reloadInProgress.compareAndSet(false, true)) {
+            send(source, "<yellow>A reload is already in progress.</yellow>");
+            return;
         }
+
+        ConfigManager configManager = VelocityLimboHandler.getConfigManager();
+        VelocityLimboHandler plugin = VelocityLimboHandler.getInstance();
+        VelocityLimboHandler.getProxyServer().getScheduler().buildTask(plugin, () -> {
+            try {
+                configManager.load();
+                plugin.applyReloadedConfiguration();
+                send(source, "<green>✔ Reload complete.</green> <gray>Configuration, messages, commands, and task schedules were refreshed.</gray>");
+            } catch (IOException | RuntimeException exception) {
+                send(source, "<red>✖ Reload failed.</red> <gray>Could not reload configuration. Check console for details.</gray>");
+                VelocityLimboHandler.getLogger().severe("Failed to reload configuration: " + exception.getMessage());
+            } finally {
+                reloadInProgress.set(false);
+            }
+        }).schedule();
     }
 
     private void handleStatus(CommandSource source) {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/commands/VlhAdminCommand.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/commands/VlhAdminCommand.java
@@ -103,7 +103,10 @@ public class VlhAdminCommand implements SimpleCommand {
         VelocityLimboHandler plugin = VelocityLimboHandler.getInstance();
         VelocityLimboHandler.getProxyServer().getScheduler().buildTask(plugin, () -> {
             try {
-                configManager.load();
+                configManager.load((limboName, directConnectName) ->
+                        VelocityLimboHandler.getProxyServer().getServer(limboName).isPresent()
+                                && VelocityLimboHandler.getProxyServer().getServer(directConnectName).isPresent()
+                );
                 plugin.applyReloadedConfiguration();
                 send(source, "<green>✔ Reload complete.</green> <gray>Configuration, messages, commands, and task schedules were refreshed.</gray>");
             } catch (IOException | RuntimeException exception) {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
@@ -1,7 +1,6 @@
 package com.akselglyholt.velocityLimboHandler.config;
 
 import com.akselglyholt.velocityLimboHandler.misc.MessageFormatter;
-
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.dvs.versioning.BasicVersioning;
 import dev.dejvokep.boostedyaml.route.Route;
@@ -18,153 +17,194 @@ import java.util.Objects;
 import java.util.logging.Logger;
 
 public class ConfigManager {
+    private static final int MIN_TASK_INTERVAL_MILLIS = 250;
+    private static final int MAX_TASK_INTERVAL_MILLIS = 60_000;
+    private static final int MAX_NOTIFY_INTERVAL_SECONDS = 3_600;
+    private static final int MAX_RECONNECT_BATCH_SIZE = 1_024;
+    private static final int MAX_NOTIFY_BATCH_SIZE = 4_096;
+
     private final Path dataDirectory;
     private final Logger logger;
-    private YamlDocument config;
-    private YamlDocument messageConfig;
-
-    // Cached values
-    private String bannedMsg;
-    private String whitelistedMsg;
-    private String maintenanceModeMsg;
-    private String queuePositionMsg;
-    private String queuePositionJoinMsg;
-    private String commandBlockedMsg;
-
-    private String limboName;
-    private String directConnectServerName;
-    private int taskInterval;
-    private int reconnectBatchSize;
-    private int queueNotifyInterval;
-    private int queueNotifyBatchSize;
-    private boolean queueEnabled;
-    private List<String> disabledCommands;
-    private boolean connectionWarnings;
-    private boolean debug;
+    private volatile Snapshot snapshot;
 
     public ConfigManager(Path dataDirectory, Logger logger) {
         this.dataDirectory = dataDirectory;
         this.logger = logger;
     }
 
-    public void load() throws IOException {
-        config = YamlDocument.create(
+    public synchronized void load() throws IOException {
+        YamlDocument loadedConfig = YamlDocument.create(
                 new File(dataDirectory.toFile(), "config.yml"),
                 Objects.requireNonNull(getClass().getResourceAsStream("/config.yml")),
                 GeneralSettings.DEFAULT,
                 LoaderSettings.builder().setAutoUpdate(true).build(),
                 DumperSettings.DEFAULT,
-                UpdaterSettings.builder().setVersioning(new BasicVersioning("file-version")).setOptionSorting(UpdaterSettings.OptionSorting.SORT_BY_DEFAULTS).build()
+                UpdaterSettings.builder()
+                        .setVersioning(new BasicVersioning("file-version"))
+                        .setOptionSorting(UpdaterSettings.OptionSorting.SORT_BY_DEFAULTS)
+                        .build()
         );
 
-        messageConfig = YamlDocument.create(
+        YamlDocument loadedMessages = YamlDocument.create(
                 new File(dataDirectory.toFile(), "messages.yml"),
                 Objects.requireNonNull(getClass().getResourceAsStream("/messages.yml")),
                 GeneralSettings.DEFAULT,
                 LoaderSettings.builder().setAutoUpdate(true).build(),
                 DumperSettings.DEFAULT,
-                UpdaterSettings.builder().setVersioning(new BasicVersioning("file-version")).setOptionSorting(UpdaterSettings.OptionSorting.SORT_BY_DEFAULTS).build()
+                UpdaterSettings.builder()
+                        .setVersioning(new BasicVersioning("file-version"))
+                        .setOptionSorting(UpdaterSettings.OptionSorting.SORT_BY_DEFAULTS)
+                        .build()
         );
 
-        config.update();
-        config.save();
+        loadedConfig.update();
+        loadedConfig.save();
+        loadedMessages.update();
+        loadedMessages.save();
 
-        messageConfig.update();
-        messageConfig.save();
+        Snapshot freshSnapshot = new Snapshot(
+                loadedConfig,
+                loadedMessages,
+                loadedMessages.getString(Route.from("bannedMessage")),
+                loadedMessages.getString(Route.from("notWhitelisted")),
+                loadedMessages.getString(Route.from("maintenanceMode")),
+                loadedMessages.getString(Route.from("queuePosition")),
+                loadedMessages.getString(Route.from("queuePositionJoin")),
+                loadedMessages.getString(Route.from("welcomeMessage")),
+                loadedMessages.getString(Route.from("commandBlocked")),
+                loadedConfig.getString(Route.from("limbo-name")),
+                loadedConfig.getString(Route.from("direct-connect-server")),
+                bounded("task-interval", loadedConfig.getInt("task-interval", 3_000),
+                        MIN_TASK_INTERVAL_MILLIS, MAX_TASK_INTERVAL_MILLIS),
+                bounded("reconnect-batch-size", loadedConfig.getInt("reconnect-batch-size", 8),
+                        1, MAX_RECONNECT_BATCH_SIZE),
+                bounded("queue-notify-interval", loadedConfig.getInt("queue-notify-interval", 30),
+                        1, MAX_NOTIFY_INTERVAL_SECONDS),
+                bounded("queue-notify-batch-size", loadedConfig.getInt("queue-notify-batch-size", 64),
+                        1, MAX_NOTIFY_BATCH_SIZE),
+                loadedConfig.getBoolean("queue-enabled", true),
+                List.copyOf(loadedConfig.getStringList("disabled-commands")),
+                loadedConfig.getBoolean("connection-warnings", false),
+                loadedConfig.getBoolean("debug", false)
+        );
 
-        cacheValues();
+        snapshot = freshSnapshot;
         MessageFormatter.clearCache();
     }
 
-    private void cacheValues() {
-        bannedMsg = messageConfig.getString(Route.from("bannedMessage"));
-        whitelistedMsg = messageConfig.getString(Route.from("notWhitelisted"));
-        maintenanceModeMsg = messageConfig.getString(Route.from("maintenanceMode"));
-        queuePositionMsg = messageConfig.getString(Route.from("queuePosition"));
-        queuePositionJoinMsg = messageConfig.getString(Route.from("queuePositionJoin"));
-        commandBlockedMsg = messageConfig.getString(Route.from("commandBlocked"));
+    private int bounded(String option, int value, int minimum, int maximum) {
+        int bounded = Math.max(minimum, Math.min(value, maximum));
+        if (bounded != value) {
+            logger.warning(option + " must be between " + minimum + " and " + maximum
+                    + "; using " + bounded + " instead of " + value + '.');
+        }
+        return bounded;
+    }
 
-        limboName = config.getString(Route.from("limbo-name"));
-        directConnectServerName = config.getString(Route.from("direct-connect-server"));
-        taskInterval = config.getInt(Route.from("task-interval"));
-        reconnectBatchSize = config.getInt("reconnect-batch-size", 8);
-        queueNotifyInterval = config.getInt(Route.from("queue-notify-interval"));
-        queueNotifyBatchSize = config.getInt("queue-notify-batch-size", 64);
-        queueEnabled = config.getBoolean(Route.from("queue-enabled"), true);
-        disabledCommands = config.getStringList("disabled-commands");
-        connectionWarnings = config.getBoolean("connection-warnings", false);
-        debug = config.getBoolean("debug", false);
+    private Snapshot current() {
+        Snapshot current = snapshot;
+        if (current == null) {
+            throw new IllegalStateException("Configuration has not been loaded");
+        }
+        return current;
     }
 
     public YamlDocument getConfig() {
-        return config;
+        return current().config();
     }
 
     public YamlDocument getMessageConfig() {
-        return messageConfig;
+        return current().messages();
     }
 
     public String getBannedMsg() {
-        return bannedMsg;
+        return current().bannedMsg();
     }
 
     public String getWhitelistedMsg() {
-        return whitelistedMsg;
+        return current().whitelistedMsg();
     }
 
     public String getMaintenanceModeMsg() {
-        return maintenanceModeMsg;
+        return current().maintenanceModeMsg();
     }
 
     public String getQueuePositionMsg() {
-        return queuePositionMsg;
+        return current().queuePositionMsg();
     }
 
     public String getQueuePositionJoinMsg() {
-        return queuePositionJoinMsg;
+        return current().queuePositionJoinMsg();
+    }
+
+    public String getWelcomeMsg() {
+        return current().welcomeMsg();
     }
 
     public String getCommandBlockedMsg() {
-        return commandBlockedMsg;
+        return current().commandBlockedMsg();
     }
 
     public String getLimboName() {
-        return limboName;
+        return current().limboName();
     }
 
     public String getDirectConnectServerName() {
-        return directConnectServerName;
+        return current().directConnectServerName();
     }
 
     public int getTaskInterval() {
-        return taskInterval;
+        return current().taskInterval();
     }
 
     public int getQueueNotifyInterval() {
-        return queueNotifyInterval;
+        return current().queueNotifyInterval();
     }
 
     public int getReconnectBatchSize() {
-        return reconnectBatchSize;
+        return current().reconnectBatchSize();
     }
 
     public int getQueueNotifyBatchSize() {
-        return queueNotifyBatchSize;
+        return current().queueNotifyBatchSize();
     }
 
     public boolean isQueueEnabled() {
-        return queueEnabled;
+        return current().queueEnabled();
     }
 
     public List<String> getDisabledCommands() {
-        return disabledCommands;
+        return current().disabledCommands();
     }
 
     public boolean isConnectionWarningsEnabled() {
-        return connectionWarnings;
+        return current().connectionWarnings();
     }
 
     public boolean isDebugEnabled() {
-        return debug;
+        return current().debug();
+    }
+
+    private record Snapshot(
+            YamlDocument config,
+            YamlDocument messages,
+            String bannedMsg,
+            String whitelistedMsg,
+            String maintenanceModeMsg,
+            String queuePositionMsg,
+            String queuePositionJoinMsg,
+            String welcomeMsg,
+            String commandBlockedMsg,
+            String limboName,
+            String directConnectServerName,
+            int taskInterval,
+            int reconnectBatchSize,
+            int queueNotifyInterval,
+            int queueNotifyBatchSize,
+            boolean queueEnabled,
+            List<String> disabledCommands,
+            boolean connectionWarnings,
+            boolean debug
+    ) {
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
@@ -1,5 +1,7 @@
 package com.akselglyholt.velocityLimboHandler.config;
 
+import com.akselglyholt.velocityLimboHandler.misc.MessageFormatter;
+
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.dvs.versioning.BasicVersioning;
 import dev.dejvokep.boostedyaml.route.Route;
@@ -71,6 +73,7 @@ public class ConfigManager {
         messageConfig.save();
 
         cacheValues();
+        MessageFormatter.clearCache();
     }
 
     private void cacheValues() {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
@@ -32,7 +32,9 @@ public class ConfigManager {
     private String limboName;
     private String directConnectServerName;
     private int taskInterval;
+    private int reconnectBatchSize;
     private int queueNotifyInterval;
+    private int queueNotifyBatchSize;
     private boolean queueEnabled;
     private List<String> disabledCommands;
     private boolean connectionWarnings;
@@ -82,7 +84,9 @@ public class ConfigManager {
         limboName = config.getString(Route.from("limbo-name"));
         directConnectServerName = config.getString(Route.from("direct-connect-server"));
         taskInterval = config.getInt(Route.from("task-interval"));
+        reconnectBatchSize = config.getInt("reconnect-batch-size", 8);
         queueNotifyInterval = config.getInt(Route.from("queue-notify-interval"));
+        queueNotifyBatchSize = config.getInt("queue-notify-batch-size", 64);
         queueEnabled = config.getBoolean(Route.from("queue-enabled"), true);
         disabledCommands = config.getStringList("disabled-commands");
         connectionWarnings = config.getBoolean("connection-warnings", false);
@@ -135,6 +139,14 @@ public class ConfigManager {
 
     public int getQueueNotifyInterval() {
         return queueNotifyInterval;
+    }
+
+    public int getReconnectBatchSize() {
+        return reconnectBatchSize;
+    }
+
+    public int getQueueNotifyBatchSize() {
+        return queueNotifyBatchSize;
     }
 
     public boolean isQueueEnabled() {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiPredicate;
 import java.util.logging.Logger;
 
 public class ConfigManager {
@@ -32,7 +33,12 @@ public class ConfigManager {
         this.logger = logger;
     }
 
-    public synchronized void load() throws IOException {
+    public void load() throws IOException {
+        load((limboName, directConnectName) -> true);
+    }
+
+    public synchronized void load(BiPredicate<String, String> serverValidator) throws IOException {
+        Objects.requireNonNull(serverValidator, "serverValidator");
         YamlDocument loadedConfig = YamlDocument.create(
                 new File(dataDirectory.toFile(), "config.yml"),
                 Objects.requireNonNull(getClass().getResourceAsStream("/config.yml")),
@@ -62,6 +68,14 @@ public class ConfigManager {
         loadedMessages.update();
         loadedMessages.save();
 
+        String limboName = loadedConfig.getString(Route.from("limbo-name"));
+        String directConnectServerName = loadedConfig.getString(Route.from("direct-connect-server"));
+        if (limboName == null || limboName.isBlank()
+                || directConnectServerName == null || directConnectServerName.isBlank()
+                || !serverValidator.test(limboName, directConnectServerName)) {
+            throw new IOException("Configured limbo or direct-connect server is not registered in Velocity");
+        }
+
         Snapshot freshSnapshot = new Snapshot(
                 loadedConfig,
                 loadedMessages,
@@ -72,8 +86,8 @@ public class ConfigManager {
                 loadedMessages.getString(Route.from("queuePositionJoin")),
                 loadedMessages.getString(Route.from("welcomeMessage")),
                 loadedMessages.getString(Route.from("commandBlocked")),
-                loadedConfig.getString(Route.from("limbo-name")),
-                loadedConfig.getString(Route.from("direct-connect-server")),
+                limboName,
+                directConnectServerName,
                 bounded("task-interval", loadedConfig.getInt("task-interval", 3_000),
                         MIN_TASK_INTERVAL_MILLIS, MAX_TASK_INTERVAL_MILLIS),
                 bounded("reconnect-batch-size", loadedConfig.getInt("reconnect-batch-size", 8),

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/CommandExecuteEventListener.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/CommandExecuteEventListener.java
@@ -10,6 +10,7 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ServerConnection;
 
 import java.util.Optional;
+import java.util.Locale;
 
 public class CommandExecuteEventListener {
     private final CommandBlocker commandBlocker;
@@ -30,7 +31,8 @@ public class CommandExecuteEventListener {
 
         if (serverConnection.isPresent()) {
             String command = event.getCommand();
-            String commandName = command.split(" ")[0].toLowerCase(); // Extract command name
+            int separator = command.indexOf(' ');
+            String commandName = (separator < 0 ? command : command.substring(0, separator)).toLowerCase(Locale.ROOT);
 
             // Get the rule for this specific command
             CommandBlockRule rule = commandBlocker.getCommandRules().get(commandName);

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/CommandExecuteEventListener.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/CommandExecuteEventListener.java
@@ -35,7 +35,7 @@ public class CommandExecuteEventListener {
             String commandName = (separator < 0 ? command : command.substring(0, separator)).toLowerCase(Locale.ROOT);
 
             // Get the rule for this specific command
-            CommandBlockRule rule = commandBlocker.getCommandRules().get(commandName);
+            CommandBlockRule rule = commandBlocker.getRule(commandName);
 
             if (rule != null && rule.shouldBlock(player)) {
                 event.setResult(CommandExecuteEvent.CommandResult.denied());

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/CommandExecuteEventListener.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/CommandExecuteEventListener.java
@@ -3,11 +3,11 @@ package com.akselglyholt.velocityLimboHandler.listeners;
 import com.akselglyholt.velocityLimboHandler.commands.CommandBlockRule;
 import com.akselglyholt.velocityLimboHandler.commands.CommandBlocker;
 import com.akselglyholt.velocityLimboHandler.config.ConfigManager;
+import com.akselglyholt.velocityLimboHandler.misc.MessageFormatter;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.command.CommandExecuteEvent;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ServerConnection;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 
 import java.util.Optional;
 
@@ -38,7 +38,7 @@ public class CommandExecuteEventListener {
             if (rule != null && rule.shouldBlock(player)) {
                 event.setResult(CommandExecuteEvent.CommandResult.denied());
                 String message = configManager.getCommandBlockedMsg();
-                player.sendMessage(MiniMessage.miniMessage().deserialize(message));
+                player.sendMessage(MessageFormatter.formatComponent(message, player));
             }
         }
     }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/ConnectionListener.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/ConnectionListener.java
@@ -36,7 +36,7 @@ public class ConnectionListener {
         if (VelocityLimboHandler.getPlayerManager().hasQueuedPlayers(intendedServer)) {
             event.setResult(ServerPreConnectEvent.ServerResult.allowed(limbo));
 
-            VelocityLimboHandler.getLogger().info(String.format("Rerouting %s to Limbo (Server %s is queued)",
+            Utility.logDebug(() -> String.format("Rerouting %s to Limbo (Server %s is queued)",
                     player.getUsername(), intendedServer.getServerInfo().getName()));
         }
     }
@@ -63,9 +63,9 @@ public class ConnectionListener {
         // Handle players who just joined Limbo
         if (Utility.doServerNamesMatch(currentServer, limbo)) {
             // Determine intended server from forced host if available
-            String virtualHost = player.getVirtualHost().map(InetSocketAddress::getHostName).orElse(null);
+            String virtualHost = player.getVirtualHost().map(InetSocketAddress::getHostString).orElse(null);
 
-            Utility.logDebug(String.format("%s landed on limbo (previousServer: %s, virtualHost: %s)",
+            Utility.logDebug(() -> String.format("%s landed on limbo (previousServer: %s, virtualHost: %s)",
                     player.getUsername(),
                     previousServer != null ? previousServer.getServerInfo().getName() : "none",
                     virtualHost != null ? virtualHost : "none"));
@@ -78,7 +78,7 @@ public class ConnectionListener {
                         .getForcedHosts()
                         .get(virtualHost);
 
-                Utility.logDebug(String.format("%s forced-host lookup for '%s': %s",
+                Utility.logDebug(() -> String.format("%s forced-host lookup for '%s': %s",
                         player.getUsername(), virtualHost,
                         forcedServers != null ? forcedServers.toString() : "no match"));
 
@@ -103,12 +103,14 @@ public class ConnectionListener {
                 } else {
                     intendedTarget = VelocityLimboHandler.getDirectConnectServer();
                 }
-                Utility.logDebug(String.format("%s no forced-host target resolved — falling back to '%s'",
-                        player.getUsername(), intendedTarget.getServerInfo().getName()));
+                RegisteredServer fallbackTarget = intendedTarget;
+                Utility.logDebug(() -> String.format("%s no forced-host target resolved — falling back to '%s'",
+                        player.getUsername(), fallbackTarget.getServerInfo().getName()));
             }
 
-            Utility.logDebug(String.format("%s will be queued for '%s'",
-                    player.getUsername(), intendedTarget.getServerInfo().getName()));
+            RegisteredServer queuedTarget = intendedTarget;
+            Utility.logDebug(() -> String.format("%s will be queued for '%s'",
+                    player.getUsername(), queuedTarget.getServerInfo().getName()));
 
             VelocityLimboHandler.getPlayerManager().addPlayer(player, intendedTarget);
         }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/managers/BackendHealthTracker.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/managers/BackendHealthTracker.java
@@ -1,0 +1,112 @@
+package com.akselglyholt.velocityLimboHandler.managers;
+
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerPing;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+final class BackendHealthTracker {
+    private static final long SUCCESS_TTL_NANOS = TimeUnit.SECONDS.toNanos(1);
+    private static final long FULL_TTL_NANOS = TimeUnit.SECONDS.toNanos(3);
+    private static final long FAILURE_BACKOFF_BASE_NANOS = TimeUnit.SECONDS.toNanos(3);
+    private static final long FAILURE_BACKOFF_MAX_NANOS = TimeUnit.SECONDS.toNanos(30);
+    private static final long PING_TIMEOUT_SECONDS = 5;
+
+    private final Map<String, ProbeState> states = new ConcurrentHashMap<>();
+
+    CompletableFuture<Availability> probe(RegisteredServer server) {
+        String serverName = server.getServerInfo().getName();
+        ProbeState state = states.computeIfAbsent(serverName, ignored -> new ProbeState());
+
+        synchronized (state) {
+            if (state.inFlight != null) {
+                return state.inFlight;
+            }
+
+            long now = System.nanoTime();
+            if (state.lastResult != null && now < state.nextProbeAtNanos) {
+                return CompletableFuture.completedFuture(state.lastResult);
+            }
+
+            CompletableFuture<Availability> probe;
+            try {
+                probe = server.ping()
+                        .orTimeout(PING_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .handle((ping, throwable) -> toAvailability(ping, throwable));
+            } catch (RuntimeException exception) {
+                probe = CompletableFuture.completedFuture(Availability.offline());
+            }
+
+            state.inFlight = probe;
+            probe.whenComplete((availability, ignored) -> finishProbe(state, availability));
+            return probe;
+        }
+    }
+
+    void invalidate(String serverName) {
+        states.remove(serverName);
+    }
+
+    void clear() {
+        states.clear();
+    }
+
+    private void finishProbe(ProbeState state, Availability availability) {
+        synchronized (state) {
+            Availability resolved = availability != null ? availability : Availability.offline();
+            state.lastResult = resolved;
+            state.inFlight = null;
+
+            long delay;
+            if (!resolved.reachable()) {
+                state.consecutiveFailures = Math.min(state.consecutiveFailures + 1, 31);
+                int shift = Math.min(state.consecutiveFailures - 1, 4);
+                delay = Math.min(FAILURE_BACKOFF_BASE_NANOS << shift, FAILURE_BACKOFF_MAX_NANOS);
+                if (delay < FAILURE_BACKOFF_MAX_NANOS) {
+                    delay = Math.min(
+                            FAILURE_BACKOFF_MAX_NANOS,
+                            delay + ThreadLocalRandom.current().nextLong(Math.max(1L, delay / 10L))
+                    );
+                }
+            } else {
+                state.consecutiveFailures = 0;
+                delay = resolved.full() ? FULL_TTL_NANOS : SUCCESS_TTL_NANOS;
+            }
+            state.nextProbeAtNanos = System.nanoTime() + delay;
+        }
+    }
+
+    private Availability toAvailability(ServerPing ping, Throwable throwable) {
+        if (throwable != null || ping == null) {
+            return Availability.offline();
+        }
+
+        return ping.getPlayers()
+                .map(players -> {
+                    int freeSlots = Math.max(0, players.getMax() - players.getOnline());
+                    return new Availability(true, freeSlots == 0, freeSlots);
+                })
+                .orElseGet(Availability::onlineWithoutPlayerCount);
+    }
+
+    record Availability(boolean reachable, boolean full, int reportedFreeSlots) {
+        static Availability offline() {
+            return new Availability(false, false, 0);
+        }
+
+        static Availability onlineWithoutPlayerCount() {
+            return new Availability(true, false, Integer.MAX_VALUE);
+        }
+    }
+
+    private static final class ProbeState {
+        private Availability lastResult;
+        private CompletableFuture<Availability> inFlight;
+        private long nextProbeAtNanos;
+        private int consecutiveFailures;
+    }
+}

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/managers/BackendHealthTracker.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/managers/BackendHealthTracker.java
@@ -52,6 +52,13 @@ final class BackendHealthTracker {
     }
 
     void clear() {
+        states.values().forEach(state -> {
+            synchronized (state) {
+                if (state.inFlight != null) {
+                    state.inFlight.cancel(false);
+                }
+            }
+        });
         states.clear();
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
@@ -76,6 +76,11 @@ public class ReconnectHandler implements AutoCloseable {
             if (!player.isActive()) {
                 return;
             }
+            if (isMaintenanceBlocked(player, server)) {
+                Utility.logDebug(() -> String.format("Skipping reconnect for %s — %s entered maintenance",
+                        player.getUsername(), server.getServerInfo().getName()));
+                return;
+            }
 
             Utility.logDebug(() -> String.format("Connecting %s to %s",
                     player.getUsername(), server.getServerInfo().getName()));
@@ -92,6 +97,18 @@ public class ReconnectHandler implements AutoCloseable {
                 playerManager.setPlayerConnecting(player, false);
             }
         }
+    }
+
+    private boolean isMaintenanceBlocked(Player player, RegisteredServer server) {
+        String serverName = server.getServerInfo().getName();
+        if (!Utility.isServerInMaintenance(serverName)) {
+            return false;
+        }
+
+        return !player.hasPermission("maintenance.admin")
+                && !player.hasPermission("maintenance.bypass")
+                && !player.hasPermission("maintenance.singleserver.bypass." + serverName)
+                && !Utility.playerMaintenanceWhitelisted(player);
     }
 
     private void handleConnectionResult(Player player, RegisteredServer server,

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
@@ -8,7 +8,6 @@ import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
 import com.velocitypowered.api.proxy.ConnectionRequestBuilder;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
-import com.velocitypowered.api.proxy.server.ServerPing;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
@@ -21,18 +20,25 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-public class ReconnectHandler {
+public class ReconnectHandler implements AutoCloseable {
     private final PlayerManager playerManager;
     private final AuthManager authManager;
     private final ConfigManager configManager;
     private final Logger logger;
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
+    private final BackendHealthTracker healthTracker;
 
     public ReconnectHandler(PlayerManager playerManager, AuthManager authManager, ConfigManager configManager, Logger logger) {
+        this(playerManager, authManager, configManager, logger, new BackendHealthTracker());
+    }
+
+    ReconnectHandler(PlayerManager playerManager, AuthManager authManager, ConfigManager configManager, Logger logger,
+                     BackendHealthTracker healthTracker) {
         this.playerManager = playerManager;
         this.authManager = authManager;
         this.configManager = configManager;
         this.logger = logger;
+        this.healthTracker = healthTracker;
     }
 
     public boolean reconnectPlayer(Player player) {
@@ -46,93 +52,98 @@ public class ReconnectHandler {
 
         playerManager.setPlayerConnecting(player, true);
 
-        // If enabled, check if a server responds to pings before connecting, asynchronously
         Utility.logDebug(String.format("Pinging %s for %s", previousServer.getServerInfo().getName(), player.getUsername()));
-        previousServer.ping().whenComplete((ping, throwable) -> {
-            if (throwable != null || ping == null) {
-                Utility.logDebug(String.format("Ping failed for %s (%s) — server likely offline",
-                        previousServer.getServerInfo().getName(),
-                        throwable != null ? throwable.getMessage() : "null ping"));
-                playerManager.setPlayerConnecting(player, false);
-                return; // Server offline
-            }
-
-            // Check if the server is full (skip if the server doesn't report player counts)
-            if (ping.getPlayers().isPresent()) {
-                ServerPing.Players serverPlayers = ping.getPlayers().get();
-                int maxPlayers = serverPlayers.getMax();
-                int onlinePlayers = serverPlayers.getOnline();
-
-                Utility.logDebug(String.format("Ping OK for %s: %d/%d players",
-                        previousServer.getServerInfo().getName(), onlinePlayers, maxPlayers));
-
-                if (maxPlayers <= onlinePlayers) {
-                    Utility.logDebug(String.format("Skipping reconnect for %s — %s is full (%d/%d)",
-                            player.getUsername(), previousServer.getServerInfo().getName(), onlinePlayers, maxPlayers));
-                    playerManager.setPlayerConnecting(player, false);
-                    return;
-                }
-            } else {
-                Utility.logDebug(String.format("Ping OK for %s: player count not reported (hide-online-players?), proceeding",
-                        previousServer.getServerInfo().getName()));
-            }
-
-            // Check if maintenance mode is enabled on Backend Server
-            if (Utility.isServerInMaintenance(previousServer.getServerInfo().getName())) {
-                // Check if the user has bypass permission for Maintenance or is admin
-                if (player.hasPermission("maintenance.admin")
-                        || player.hasPermission("maintenance.bypass")
-                        || player.hasPermission("maintenance.singleserver.bypass." + previousServer.getServerInfo().getName())
-                        || Utility.playerMaintenanceWhitelisted(player)) {
-                    logger.info("[Maintenance Bypass] " + player.getUsername() + " bypassed queue to join " + previousServer.getServerInfo().getName());
-                } else {
-                    playerManager.setPlayerConnecting(player, false);
-                    return;
-                }
-            }
-
-            Utility.logInformational(String.format("Connecting %s to %s", player.getUsername(), previousServer.getServerInfo().getName()));
-
-            player.createConnectionRequest(previousServer).connect().whenComplete(((result, connectionThrowable) -> {
-                playerManager.setPlayerConnecting(player, false);
-
-                if (result.isSuccessful()) {
-                    Utility.logInformational(String.format("Successfully reconnected %s to %s", player.getUsername(), previousServer.getServerInfo().getName()));
-                    playerManager.removePlayerIssue(player);
-                    return;
-                }
-
-                if (result.getStatus() == ConnectionRequestBuilder.Status.CONNECTION_IN_PROGRESS) return;
-
-                if (configManager.isConnectionWarningsEnabled()) {
-                    Utility.logInformational(String.format("Connection failed for %s to %s. Result status: %s",
-                            player.getUsername(),
-                            previousServer.getServerInfo().getName(),
-                            result.getStatus()));
-                }
-
-                if (result.getStatus() == ConnectionRequestBuilder.Status.SERVER_DISCONNECTED) {
-                    Optional<Component> reasonOpt = result.getReasonComponent();
-                    if (reasonOpt.isPresent()) {
-                        Component reason = reasonOpt.get();
-                        if (!playerConnectIssue(player, reason)) {
-                            String plainReason = PlainTextComponentSerializer.plainText().serialize(reason);
-                            player.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + plainReason + "</red>"));
-                        }
-                    }
-                    return;
-                }
-
-                if (connectionThrowable != null) {
-                    String errorMessage = connectionThrowable.getMessage();
-                    if (errorMessage != null && !errorMessage.isEmpty()) {
-                        player.sendMessage(miniMessage.deserialize("<red>❌ Failed to connect: " + errorMessage + "</red>"));
-                    }
-                }
-            }));
-        });
+        healthTracker.probe(previousServer).whenComplete((availability, probeThrowable) ->
+                handleProbeResult(player, previousServer, availability, probeThrowable)
+        );
 
         return true;
+    }
+
+    private void handleProbeResult(Player player, RegisteredServer server,
+                                   BackendHealthTracker.Availability availability, Throwable throwable) {
+        boolean connectionStarted = false;
+        try {
+            if (throwable != null || availability == null || !availability.reachable()) {
+                Utility.logDebug(String.format("Ping failed for %s — server likely offline",
+                        server.getServerInfo().getName()));
+                return;
+            }
+            if (availability.full()) {
+                Utility.logDebug(String.format("Skipping reconnect for %s — %s reports no free slots",
+                        player.getUsername(), server.getServerInfo().getName()));
+                return;
+            }
+            if (!player.isActive()) {
+                return;
+            }
+
+            Utility.logInformational(String.format("Connecting %s to %s",
+                    player.getUsername(), server.getServerInfo().getName()));
+            var connectionFuture = player.createConnectionRequest(server).connect();
+            connectionStarted = true;
+            connectionFuture.whenComplete((result, connectionThrowable) ->
+                    handleConnectionResult(player, server, result, connectionThrowable)
+            );
+        } catch (RuntimeException exception) {
+            healthTracker.invalidate(server.getServerInfo().getName());
+            logger.warning("Failed to start reconnect for " + player.getUsername() + ": " + exception.getMessage());
+        } finally {
+            if (!connectionStarted) {
+                playerManager.setPlayerConnecting(player, false);
+            }
+        }
+    }
+
+    private void handleConnectionResult(Player player, RegisteredServer server,
+                                        ConnectionRequestBuilder.Result result, Throwable throwable) {
+        try {
+            if (throwable != null || result == null) {
+                healthTracker.invalidate(server.getServerInfo().getName());
+                if (configManager.isConnectionWarningsEnabled()) {
+                    logger.warning("Connection failed for " + player.getUsername() + " to "
+                            + server.getServerInfo().getName() + ": "
+                            + (throwable == null ? "empty result" : throwable.getMessage()));
+                }
+                return;
+            }
+
+            if (result.isSuccessful()) {
+                Utility.logInformational(String.format("Successfully reconnected %s to %s",
+                        player.getUsername(), server.getServerInfo().getName()));
+                playerManager.removePlayerIssue(player);
+                return;
+            }
+
+            if (result.getStatus() == ConnectionRequestBuilder.Status.CONNECTION_IN_PROGRESS) {
+                return;
+            }
+
+            if (configManager.isConnectionWarningsEnabled()) {
+                Utility.logInformational(String.format("Connection failed for %s to %s. Result status: %s",
+                        player.getUsername(), server.getServerInfo().getName(), result.getStatus()));
+            }
+
+            if (result.getStatus() == ConnectionRequestBuilder.Status.SERVER_DISCONNECTED) {
+                Optional<Component> reasonOpt = result.getReasonComponent();
+                if (reasonOpt.isPresent()) {
+                    Component reason = reasonOpt.get();
+                    if (!playerConnectIssue(player, reason)) {
+                        String plainReason = PlainTextComponentSerializer.plainText().serialize(reason);
+                        player.sendMessage(Component.text("❌ Failed to connect: " + plainReason, NamedTextColor.RED));
+                    }
+                }
+            }
+        } catch (RuntimeException exception) {
+            logger.warning("Failed to process reconnect result for " + player.getUsername() + ": " + exception.getMessage());
+        } finally {
+            playerManager.setPlayerConnecting(player, false);
+        }
+    }
+
+    @Override
+    public void close() {
+        healthTracker.clear();
     }
 
     private Optional<Component> extractBanReason(TranslatableComponent component) {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
@@ -13,7 +13,6 @@ import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
 import net.kyori.adventure.text.TranslationArgument;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 
 import java.util.List;
@@ -25,7 +24,6 @@ public class ReconnectHandler implements AutoCloseable {
     private final AuthManager authManager;
     private final ConfigManager configManager;
     private final Logger logger;
-    private final MiniMessage miniMessage = MiniMessage.miniMessage();
     private final BackendHealthTracker healthTracker;
 
     public ReconnectHandler(PlayerManager playerManager, AuthManager authManager, ConfigManager configManager, Logger logger) {
@@ -159,7 +157,7 @@ public class ReconnectHandler implements AutoCloseable {
         if (reason instanceof TranslatableComponent translatable) {
             String key = translatable.key();
             if (key.contains("banned")) {
-                Component message = miniMessage.deserialize(MessageFormatter.formatMessage(configManager.getBannedMsg(), player));
+                Component message = MessageFormatter.formatComponent(configManager.getBannedMsg(), player);
                 Optional<Component> banReason = extractBanReason(translatable);
                 if (banReason.isPresent()) {
                     message = message.append(Component.newline())
@@ -172,7 +170,7 @@ public class ReconnectHandler implements AutoCloseable {
                 return true;
             }
             if (key.contains("not_whitelisted")) {
-                player.sendMessage(miniMessage.deserialize(MessageFormatter.formatMessage(configManager.getWhitelistedMsg(), player)));
+                player.sendMessage(MessageFormatter.formatComponent(configManager.getWhitelistedMsg(), player));
                 playerManager.addPlayerWithIssue(player, "not_whitelisted");
                 playerManager.removePlayerFromQueue(player);
                 return true;
@@ -180,7 +178,7 @@ public class ReconnectHandler implements AutoCloseable {
         }
 
         if (reason instanceof TextComponent textComponent && textComponent.content().toLowerCase().contains("whitelist")) {
-            player.sendMessage(miniMessage.deserialize(MessageFormatter.formatMessage(configManager.getWhitelistedMsg(), player)));
+            player.sendMessage(MessageFormatter.formatComponent(configManager.getWhitelistedMsg(), player));
             playerManager.addPlayerWithIssue(player, "not_whitelisted");
             playerManager.removePlayerFromQueue(player);
             return true;

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
@@ -16,6 +16,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -177,7 +178,8 @@ public class ReconnectHandler implements AutoCloseable {
             }
         }
 
-        if (reason instanceof TextComponent textComponent && textComponent.content().toLowerCase().contains("whitelist")) {
+        if (reason instanceof TextComponent textComponent
+                && textComponent.content().toLowerCase(Locale.ROOT).contains("whitelist")) {
             player.sendMessage(MessageFormatter.formatComponent(configManager.getWhitelistedMsg(), player));
             playerManager.addPlayerWithIssue(player, "not_whitelisted");
             playerManager.removePlayerFromQueue(player);

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandler.java
@@ -50,7 +50,7 @@ public class ReconnectHandler implements AutoCloseable {
 
         playerManager.setPlayerConnecting(player, true);
 
-        Utility.logDebug(String.format("Pinging %s for %s", previousServer.getServerInfo().getName(), player.getUsername()));
+        Utility.logDebug(() -> String.format("Pinging %s for %s", previousServer.getServerInfo().getName(), player.getUsername()));
         healthTracker.probe(previousServer).whenComplete((availability, probeThrowable) ->
                 handleProbeResult(player, previousServer, availability, probeThrowable)
         );
@@ -63,12 +63,12 @@ public class ReconnectHandler implements AutoCloseable {
         boolean connectionStarted = false;
         try {
             if (throwable != null || availability == null || !availability.reachable()) {
-                Utility.logDebug(String.format("Ping failed for %s — server likely offline",
+                Utility.logDebug(() -> String.format("Ping failed for %s — server likely offline",
                         server.getServerInfo().getName()));
                 return;
             }
             if (availability.full()) {
-                Utility.logDebug(String.format("Skipping reconnect for %s — %s reports no free slots",
+                Utility.logDebug(() -> String.format("Skipping reconnect for %s — %s reports no free slots",
                         player.getUsername(), server.getServerInfo().getName()));
                 return;
             }
@@ -76,7 +76,7 @@ public class ReconnectHandler implements AutoCloseable {
                 return;
             }
 
-            Utility.logInformational(String.format("Connecting %s to %s",
+            Utility.logDebug(() -> String.format("Connecting %s to %s",
                     player.getUsername(), server.getServerInfo().getName()));
             var connectionFuture = player.createConnectionRequest(server).connect();
             connectionStarted = true;
@@ -107,7 +107,7 @@ public class ReconnectHandler implements AutoCloseable {
             }
 
             if (result.isSuccessful()) {
-                Utility.logInformational(String.format("Successfully reconnected %s to %s",
+                Utility.logDebug(() -> String.format("Successfully reconnected %s to %s",
                         player.getUsername(), server.getServerInfo().getName()));
                 playerManager.removePlayerIssue(player);
                 return;

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/InMemoryReconnectBlocker.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/InMemoryReconnectBlocker.java
@@ -2,20 +2,20 @@ package com.akselglyholt.velocityLimboHandler.misc;
 
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
 
 public final class InMemoryReconnectBlocker implements ReconnectBlocker {
-    private final ConcurrentHashMap<UUID, Boolean> map = new ConcurrentHashMap<>();
+    private final Set<UUID> blockedPlayers = ConcurrentHashMap.newKeySet();
 
     @Override public void block(UUID id, String reason) {
-        map.put(id, Boolean.TRUE);
+        blockedPlayers.add(id);
     }
 
     @Override public void unblock(UUID id) {
-        map.remove(id);
+        blockedPlayers.remove(id);
     }
 
     @Override public boolean isBlocked(UUID id) {
-        return map.containsKey(id);
+        return blockedPlayers.contains(id);
     }
 }
-

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/MessageFormatter.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/MessageFormatter.java
@@ -3,9 +3,21 @@ package com.akselglyholt.velocityLimboHandler.misc;
 import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MessageFormatter {
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
+    private static final Map<String, CompiledMessage> COMPILED_MESSAGES = new ConcurrentHashMap<>();
+
     public static String formatMessage(String msg, Player player) {
+        return formatMessage(msg, player, null, null);
+    }
+
+    public static String formatMessage(String msg, Player player, Integer knownPosition, RegisteredServer knownServer) {
         RegisteredServer server = null;
 
         if (msg.contains("[player]")) {
@@ -13,16 +25,20 @@ public class MessageFormatter {
         }
 
         if (msg.contains("[queue-position]")) {
-            int position = VelocityLimboHandler.getPlayerManager().getQueuePosition(player);
+            int position = knownPosition != null
+                    ? knownPosition
+                    : VelocityLimboHandler.getPlayerManager().getQueuePosition(player);
             msg = msg.replace("[queue-position]", Integer.toString(position));
         }
 
         if (msg.contains("[queue-size]")) {
-            if (server == null) {
+            if (knownServer != null) {
+                server = knownServer;
+            } else if (server == null) {
                 server = VelocityLimboHandler.getPlayerManager().getPreviousServer(player);
             }
 
-            int size = VelocityLimboHandler.getPlayerManager().getQueueForServer(server.getServerInfo().getName()).size();
+            int size = VelocityLimboHandler.getPlayerManager().getQueueSize(server.getServerInfo().getName());
             msg = msg.replace("[queue-size]", Integer.toString(size));
         }
 
@@ -32,7 +48,9 @@ public class MessageFormatter {
         }
 
         if (msg.contains("[queued-server]")) {
-            if (server == null) {
+            if (knownServer != null) {
+                server = knownServer;
+            } else if (server == null) {
                 server = VelocityLimboHandler.getPlayerManager().getPreviousServer(player);
             }
 
@@ -41,5 +59,75 @@ public class MessageFormatter {
         }
 
         return msg;
+    }
+
+    public static Component formatComponent(String message, Player player) {
+        return formatComponent(message, player, null, null);
+    }
+
+    public static Component formatComponent(String message, Player player, Integer knownPosition,
+                                            RegisteredServer knownServer) {
+        return COMPILED_MESSAGES.computeIfAbsent(message, CompiledMessage::new)
+                .render(player, knownPosition, knownServer);
+    }
+
+    public static void clearCache() {
+        COMPILED_MESSAGES.clear();
+    }
+
+    private static final class CompiledMessage {
+        private final Component template;
+        private final boolean hasPlayer;
+        private final boolean hasQueuePosition;
+        private final boolean hasQueueSize;
+        private final boolean hasTotalLimbo;
+        private final boolean hasQueuedServer;
+
+        private CompiledMessage(String message) {
+            template = MINI_MESSAGE.deserialize(message);
+            hasPlayer = message.contains("[player]");
+            hasQueuePosition = message.contains("[queue-position]");
+            hasQueueSize = message.contains("[queue-size]");
+            hasTotalLimbo = message.contains("[total-limbo]");
+            hasQueuedServer = message.contains("[queued-server]");
+        }
+
+        private Component render(Player player, Integer knownPosition, RegisteredServer knownServer) {
+            Component result = template;
+            RegisteredServer server = knownServer;
+
+            if (hasPlayer) {
+                result = replaceLiteral(result, "[player]", Component.text(player.getUsername()));
+            }
+            if (hasQueuePosition) {
+                int position = knownPosition != null
+                        ? knownPosition
+                        : VelocityLimboHandler.getPlayerManager().getQueuePosition(player);
+                result = replaceLiteral(result, "[queue-position]", Component.text(position));
+            }
+            if (hasQueueSize) {
+                if (server == null) {
+                    server = VelocityLimboHandler.getPlayerManager().getPreviousServer(player);
+                }
+                int size = VelocityLimboHandler.getPlayerManager().getQueueSize(server.getServerInfo().getName());
+                result = replaceLiteral(result, "[queue-size]", Component.text(size));
+            }
+            if (hasTotalLimbo) {
+                int size = VelocityLimboHandler.getLimboServer().getPlayersConnected().size();
+                result = replaceLiteral(result, "[total-limbo]", Component.text(size));
+            }
+            if (hasQueuedServer) {
+                if (server == null) {
+                    server = VelocityLimboHandler.getPlayerManager().getPreviousServer(player);
+                }
+                result = replaceLiteral(result, "[queued-server]", Component.text(server.getServerInfo().getName()));
+            }
+
+            return result;
+        }
+
+        private Component replaceLiteral(Component source, String literal, Component replacement) {
+            return source.replaceText(builder -> builder.matchLiteral(literal).replacement(replacement));
+        }
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -44,7 +45,7 @@ public class Utility {
     public static void sendWelcomeMessage(Player player, String reason) {
         if (reason == null) reason = "unknown";
 
-        Component message = switch (reason.toLowerCase()) {
+        Component message = switch (reason.toLowerCase(Locale.ROOT)) {
             case "afk" -> AFK_MESSAGE;
             case "server-restart" -> SERVER_RESTART_MESSAGE;
             case "connection-issue" -> CONNECTION_ISSUE_MESSAGE;

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 public class Utility {
     private static final MiniMessage miniMessage = MiniMessage.miniMessage();
@@ -72,8 +73,16 @@ public class Utility {
     }
 
     public static void logDebug(String message) {
-        if (VelocityLimboHandler.getConfigManager().isDebugEnabled()) {
+        var configManager = VelocityLimboHandler.getConfigManager();
+        if (configManager != null && configManager.isDebugEnabled()) {
             VelocityLimboHandler.getLogger().info("[DEBUG] " + message);
+        }
+    }
+
+    public static void logDebug(Supplier<String> messageSupplier) {
+        var configManager = VelocityLimboHandler.getConfigManager();
+        if (configManager != null && configManager.isDebugEnabled()) {
+            VelocityLimboHandler.getLogger().info("[DEBUG] " + messageSupplier.get());
         }
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
@@ -15,16 +15,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Utility {
     private static final MiniMessage miniMessage = MiniMessage.miniMessage();
     private static final String welcomeMsg = VelocityLimboHandler.getMessageConfig().getString(Route.from("welcomeMessage"));
-    private static final Map<Class<?>, Method> IS_MAINTENANCE_NO_ARG_CACHE = new ConcurrentHashMap<>();
-    private static final Map<Class<?>, Method> IS_MAINTENANCE_STRING_CACHE = new ConcurrentHashMap<>();
-    private static final Map<Class<?>, Method> GET_SERVER_CACHE = new ConcurrentHashMap<>();
-    private static final Map<Class<?>, Method> IS_MAINTENANCE_SERVER_CACHE = new ConcurrentHashMap<>();
-    private static final Map<Class<?>, Method> GET_SETTINGS_CACHE = new ConcurrentHashMap<>();
-    private static final Map<Class<?>, Method> GET_WHITELISTED_PLAYERS_CACHE = new ConcurrentHashMap<>();
+    private static final Object MAINTENANCE_ADAPTER_LOCK = new Object();
+    private static volatile MaintenanceAdapter maintenanceAdapter;
 
     // Returns whether the names of the servers match.
     public static boolean doServerNamesMatch(@NotNull RegisteredServer var0, @NotNull RegisteredServer var1) {
@@ -74,37 +71,6 @@ public class Utility {
         }
     }
 
-    private static Method getCachedMethod(Map<Class<?>, Method> cache, Class<?> targetClass, String methodName, Class<?>... paramTypes) {
-        return cache.computeIfAbsent(targetClass, key -> {
-            try {
-                return key.getMethod(methodName, paramTypes);
-            } catch (NoSuchMethodException ignored) {
-                return null;
-            }
-        });
-    }
-
-    private static Method resolveServerMaintenanceMethod(Class<?> apiClass, Class<?> serverClass) {
-        Method cached = IS_MAINTENANCE_SERVER_CACHE.get(apiClass);
-        if (cached != null && cached.getParameterTypes()[0].isAssignableFrom(serverClass)) {
-            return cached;
-        }
-
-        for (Method method : apiClass.getMethods()) {
-            if (!method.getName().equals("isMaintenance") || method.getParameterCount() != 1) {
-                continue;
-            }
-
-            Class<?> paramType = method.getParameterTypes()[0];
-            if (paramType.isAssignableFrom(serverClass)) {
-                IS_MAINTENANCE_SERVER_CACHE.put(apiClass, method);
-                return method;
-            }
-        }
-
-        return null;
-    }
-
     public static boolean hasMaintenance() {
         return VelocityLimboHandler.hasMaintenancePlugin();
     }
@@ -119,59 +85,8 @@ public class Utility {
             return false; // No maintenance plugin, assume not in maintenance
         }
 
-        try {
-            Object maintenanceAPI = VelocityLimboHandler.getMaintenanceAPI();
-            if (maintenanceAPI == null) {
-                return false;
-            }
-
-            Class<?> apiClass = maintenanceAPI.getClass();
-
-            // First check if the entire proxy is in maintenance
-            Method globalMaintenanceMethod = getCachedMethod(IS_MAINTENANCE_NO_ARG_CACHE, apiClass, "isMaintenance");
-            if (globalMaintenanceMethod != null) {
-                try {
-                    boolean globalMaintenance = (boolean) globalMaintenanceMethod.invoke(maintenanceAPI);
-                    if (globalMaintenance) {
-                        return true;
-                    }
-                } catch (Exception ignored) {
-                    // Ignore and continue to server-specific checks
-                }
-            }
-
-            // Try direct name-based check first
-            Method stringMaintenanceMethod = getCachedMethod(IS_MAINTENANCE_STRING_CACHE, apiClass, "isMaintenance", String.class);
-            if (stringMaintenanceMethod != null) {
-                try {
-                    return (boolean) stringMaintenanceMethod.invoke(maintenanceAPI, serverName);
-                } catch (Exception ignored) {
-                    // Ignore and continue to server-object checks
-                }
-            }
-
-            // Try server-object based check
-            Method getServerMethod = getCachedMethod(GET_SERVER_CACHE, apiClass, "getServer", String.class);
-            if (getServerMethod == null) {
-                return false;
-            }
-
-            Object server = getServerMethod.invoke(maintenanceAPI, serverName);
-            if (server == null) {
-                return false;
-            }
-
-            Method serverMaintenanceMethod = resolveServerMaintenanceMethod(apiClass, server.getClass());
-            if (serverMaintenanceMethod == null) {
-                return false;
-            }
-
-            return (boolean) serverMaintenanceMethod.invoke(maintenanceAPI, server);
-
-        } catch (Exception e) {
-            VelocityLimboHandler.getLogger().warning("Failed to check maintenance status for server '" + serverName + "': " + e.getMessage());
-            return false;
-        }
+        Object maintenanceAPI = VelocityLimboHandler.getMaintenanceAPI();
+        return maintenanceAPI != null && getMaintenanceAdapter(maintenanceAPI).isServerInMaintenance(serverName);
     }
 
     /**
@@ -184,45 +99,149 @@ public class Utility {
             return false;
         }
 
-        try {
-            Object maintenanceAPI = VelocityLimboHandler.getMaintenanceAPI();
-            if (maintenanceAPI == null) {
+        Object maintenanceAPI = VelocityLimboHandler.getMaintenanceAPI();
+        return maintenanceAPI != null && getMaintenanceAdapter(maintenanceAPI).isWhitelisted(player.getUniqueId());
+    }
+
+    public static void clearMaintenanceAdapter() {
+        maintenanceAdapter = null;
+    }
+
+    private static MaintenanceAdapter getMaintenanceAdapter(Object maintenanceAPI) {
+        MaintenanceAdapter current = maintenanceAdapter;
+        if (current != null && current.isFor(maintenanceAPI)) {
+            return current;
+        }
+
+        synchronized (MAINTENANCE_ADAPTER_LOCK) {
+            current = maintenanceAdapter;
+            if (current == null || !current.isFor(maintenanceAPI)) {
+                current = new MaintenanceAdapter(maintenanceAPI);
+                maintenanceAdapter = current;
+            }
+            return current;
+        }
+    }
+
+    private static final class MaintenanceAdapter {
+        private final Object api;
+        private final Optional<Method> globalMaintenanceMethod;
+        private final Optional<Method> stringMaintenanceMethod;
+        private final Optional<Method> getServerMethod;
+        private final Optional<Method> getSettingsMethod;
+        private final Map<Class<?>, Optional<Method>> serverMaintenanceMethods = new ConcurrentHashMap<>();
+        private final Map<Class<?>, Optional<Method>> whitelistMethods = new ConcurrentHashMap<>();
+        private final AtomicBoolean failureLogged = new AtomicBoolean();
+
+        private MaintenanceAdapter(Object api) {
+            this.api = api;
+            Class<?> apiClass = api.getClass();
+            globalMaintenanceMethod = findMethod(apiClass, "isMaintenance");
+            stringMaintenanceMethod = findMethod(apiClass, "isMaintenance", String.class);
+            getServerMethod = findMethod(apiClass, "getServer", String.class);
+            getSettingsMethod = findMethod(apiClass, "getSettings");
+        }
+
+        private boolean isFor(Object candidate) {
+            return api == candidate;
+        }
+
+        private boolean isServerInMaintenance(String serverName) {
+            if (globalMaintenanceMethod.isPresent()) {
+                Boolean globalMaintenance = invokeBoolean(globalMaintenanceMethod.get());
+                if (Boolean.TRUE.equals(globalMaintenance)) {
+                    return true;
+                }
+            }
+
+            if (stringMaintenanceMethod.isPresent()) {
+                Boolean serverMaintenance = invokeBoolean(stringMaintenanceMethod.get(), serverName);
+                if (serverMaintenance != null) {
+                    return serverMaintenance;
+                }
+            }
+
+            if (getServerMethod.isEmpty()) {
                 return false;
             }
 
-            Method getSettingsMethod = getCachedMethod(GET_SETTINGS_CACHE, maintenanceAPI.getClass(), "getSettings");
-            if (getSettingsMethod == null) {
+            try {
+                Object server = getServerMethod.get().invoke(api, serverName);
+                if (server == null) {
+                    return false;
+                }
+
+                Optional<Method> serverMethod = serverMaintenanceMethods.computeIfAbsent(
+                        server.getClass(),
+                        serverClass -> findServerMaintenanceMethod(api.getClass(), serverClass)
+                );
+                return serverMethod.isPresent() && Boolean.TRUE.equals(invokeBoolean(serverMethod.get(), server));
+            } catch (ReflectiveOperationException | RuntimeException exception) {
+                logFailureOnce("server maintenance", exception);
                 return false;
             }
+        }
 
-            Object settings = getSettingsMethod.invoke(maintenanceAPI);
-            if (settings == null) {
+        private boolean isWhitelisted(UUID playerId) {
+            try {
+                if (getSettingsMethod.isEmpty()) {
+                    return false;
+                }
+                Object settings = getSettingsMethod.get().invoke(api);
+                if (settings == null) {
+                    return false;
+                }
+
+                Optional<Method> whitelistMethod = whitelistMethods.computeIfAbsent(
+                        settings.getClass(),
+                        settingsClass -> findMethod(settingsClass, "getWhitelistedPlayers")
+                );
+                if (whitelistMethod.isEmpty()) {
+                    return false;
+                }
+
+                Object whitelist = whitelistMethod.get().invoke(settings);
+                return whitelist instanceof Map<?, ?> whitelistMap && whitelistMap.containsKey(playerId);
+            } catch (ReflectiveOperationException | RuntimeException exception) {
+                logFailureOnce("maintenance whitelist", exception);
                 return false;
             }
+        }
 
-            Method getWhitelistedPlayersMethod = getCachedMethod(
-                    GET_WHITELISTED_PLAYERS_CACHE,
-                    settings.getClass(),
-                    "getWhitelistedPlayers"
-            );
-            if (getWhitelistedPlayersMethod == null) {
-                return false;
+        private void logFailureOnce(String operation, Exception exception) {
+            if (failureLogged.compareAndSet(false, true)) {
+                VelocityLimboHandler.getLogger().warning(
+                        "Failed to access " + operation + " API: " + exception.getMessage()
+                );
             }
+        }
 
-            Object whitelistMapObj = getWhitelistedPlayersMethod.invoke(settings);
-
-            if (!(whitelistMapObj instanceof Map<?, ?>)) {
-                return false;
+        private Boolean invokeBoolean(Method method, Object... arguments) {
+            try {
+                return (Boolean) method.invoke(api, arguments);
+            } catch (ReflectiveOperationException | RuntimeException exception) {
+                logFailureOnce("maintenance", exception);
+                return null;
             }
+        }
 
-            @SuppressWarnings("unchecked")
-            Map<UUID, String> whitelistedPlayers = (Map<UUID, String>) whitelistMapObj;
+        private static Optional<Method> findMethod(Class<?> targetClass, String name, Class<?>... parameterTypes) {
+            try {
+                return Optional.of(targetClass.getMethod(name, parameterTypes));
+            } catch (NoSuchMethodException ignored) {
+                return Optional.empty();
+            }
+        }
 
-            return whitelistedPlayers.containsKey(player.getUniqueId());
-
-        } catch (Exception e) {
-            VelocityLimboHandler.getLogger().warning("Failed to check if player is whitelisted in Maintenance plugin: " + e.getMessage());
-            return false;
+        private static Optional<Method> findServerMaintenanceMethod(Class<?> apiClass, Class<?> serverClass) {
+            for (Method method : apiClass.getMethods()) {
+                if (method.getName().equals("isMaintenance")
+                        && method.getParameterCount() == 1
+                        && method.getParameterTypes()[0].isAssignableFrom(serverClass)) {
+                    return Optional.of(method);
+                }
+            }
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
@@ -20,6 +20,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class Utility {
     private static final MiniMessage miniMessage = MiniMessage.miniMessage();
     private static final String welcomeMsg = VelocityLimboHandler.getMessageConfig().getString(Route.from("welcomeMessage"));
+    private static final Component AFK_MESSAGE = miniMessage.deserialize(
+            "<yellow>⏳ You were inactive for too long and moved to Limbo.</yellow>\n"
+                    + "<gray>You will be reconnected when you interact with the game.</gray>"
+    );
+    private static final Component SERVER_RESTART_MESSAGE = miniMessage.deserialize(
+            "<red>🔄 The server is restarting, so you have been moved to Limbo.</red>\n"
+                    + "<gray>You will be reconnected automatically when the server is back.</gray>"
+    );
+    private static final Component CONNECTION_ISSUE_MESSAGE = miniMessage.deserialize(
+            "<dark_red>⚠ You had connection issues and were placed in Limbo.</dark_red>\n"
+                    + "<gray>Try reconnecting or wait for a stable connection.</gray>"
+    );
     private static final Object MAINTENANCE_ADAPTER_LOCK = new Object();
     private static volatile MaintenanceAdapter maintenanceAdapter;
 
@@ -33,16 +45,10 @@ public class Utility {
         if (reason == null) reason = "unknown";
 
         Component message = switch (reason.toLowerCase()) {
-            case "afk" ->
-                    miniMessage.deserialize("<yellow>⏳ You were inactive for too long and moved to Limbo.</yellow>\n" +
-                            "<gray>You will be reconnected when you interact with the game.</gray>");
-            case "server-restart" ->
-                    miniMessage.deserialize("<red>🔄 The server is restarting, so you have been moved to Limbo.</red>\n" +
-                            "<gray>You will be reconnected automatically when the server is back.</gray>");
-            case "connection-issue" ->
-                    miniMessage.deserialize("<dark_red>⚠ You had connection issues and were placed in Limbo.</dark_red>\n" +
-                            "<gray>Try reconnecting or wait for a stable connection.</gray>");
-            default -> miniMessage.deserialize(MessageFormatter.formatMessage(welcomeMsg, player));
+            case "afk" -> AFK_MESSAGE;
+            case "server-restart" -> SERVER_RESTART_MESSAGE;
+            case "connection-issue" -> CONNECTION_ISSUE_MESSAGE;
+            default -> MessageFormatter.formatComponent(welcomeMsg, player);
         };
 
         player.sendMessage(message);

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/misc/Utility.java
@@ -20,7 +20,6 @@ import java.util.function.Supplier;
 
 public class Utility {
     private static final MiniMessage miniMessage = MiniMessage.miniMessage();
-    private static final String welcomeMsg = VelocityLimboHandler.getMessageConfig().getString(Route.from("welcomeMessage"));
     private static final Component AFK_MESSAGE = miniMessage.deserialize(
             "<yellow>⏳ You were inactive for too long and moved to Limbo.</yellow>\n"
                     + "<gray>You will be reconnected when you interact with the game.</gray>"
@@ -49,7 +48,9 @@ public class Utility {
             case "afk" -> AFK_MESSAGE;
             case "server-restart" -> SERVER_RESTART_MESSAGE;
             case "connection-issue" -> CONNECTION_ISSUE_MESSAGE;
-            default -> MessageFormatter.formatComponent(welcomeMsg, player);
+            default -> MessageFormatter.formatComponent(
+                    VelocityLimboHandler.getMessageConfig().getString(Route.from("welcomeMessage")), player
+            );
         };
 
         player.sendMessage(message);

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerConnectionState.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerConnectionState.java
@@ -33,6 +33,10 @@ final class PlayerConnectionState {
         states.remove(playerId);
     }
 
+    void removePlayerStateIf(UUID playerId, Predicate<UUID> shouldRemove) {
+        states.computeIfPresent(playerId, (ignored, state) -> shouldRemove.test(playerId) ? null : state);
+    }
+
     boolean isConnecting(UUID playerId) {
         State state = states.get(playerId);
         return state != null && state.connecting;

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerConnectionState.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerConnectionState.java
@@ -2,66 +2,90 @@ package com.akselglyholt.velocityLimboHandler.storage;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
 final class PlayerConnectionState {
-    private final Map<UUID, String> playerData = new ConcurrentHashMap<>();
-    private final Set<UUID> connectingPlayers = ConcurrentHashMap.newKeySet();
-    private final Map<UUID, String> playerConnectionIssues = new ConcurrentHashMap<>();
+    private final Map<UUID, State> states = new ConcurrentHashMap<>();
 
     void registerPlayer(UUID playerId, String serverName) {
-        playerData.put(playerId, serverName);
+        states.compute(playerId, (ignored, state) -> {
+            if (state == null) {
+                return new State(serverName);
+            }
+            state.serverName = serverName;
+            return state;
+        });
     }
 
     Optional<String> getRegisteredServer(UUID playerId) {
-        return Optional.ofNullable(playerData.get(playerId));
+        State state = states.get(playerId);
+        return state == null ? Optional.empty() : Optional.ofNullable(state.serverName);
     }
 
     boolean isRegistered(UUID playerId) {
-        return playerData.containsKey(playerId);
+        State state = states.get(playerId);
+        return state != null && state.serverName != null;
     }
 
     void removePlayerState(UUID playerId) {
-        playerData.remove(playerId);
-        connectingPlayers.remove(playerId);
-        playerConnectionIssues.remove(playerId);
+        states.remove(playerId);
     }
 
     boolean isConnecting(UUID playerId) {
-        return connectingPlayers.contains(playerId);
+        State state = states.get(playerId);
+        return state != null && state.connecting;
     }
 
     void setConnecting(UUID playerId, boolean connecting) {
         if (connecting) {
-            connectingPlayers.add(playerId);
+            states.computeIfAbsent(playerId, ignored -> new State(null)).connecting = true;
             return;
         }
 
-        connectingPlayers.remove(playerId);
+        states.computeIfPresent(playerId, (ignored, state) -> {
+            state.connecting = false;
+            return state.isEmpty() ? null : state;
+        });
     }
 
     void addConnectionIssue(UUID playerId, String issue) {
-        playerConnectionIssues.put(playerId, issue);
+        states.computeIfAbsent(playerId, ignored -> new State(null)).connectionIssue = issue;
     }
 
     boolean hasConnectionIssue(UUID playerId) {
-        return playerConnectionIssues.containsKey(playerId);
+        State state = states.get(playerId);
+        return state != null && state.connectionIssue != null;
     }
 
     String getConnectionIssue(UUID playerId) {
-        return playerConnectionIssues.get(playerId);
+        State state = states.get(playerId);
+        return state == null ? null : state.connectionIssue;
     }
 
     void removeConnectionIssue(UUID playerId) {
-        playerConnectionIssues.remove(playerId);
+        states.computeIfPresent(playerId, (ignored, state) -> {
+            state.connectionIssue = null;
+            return state.isEmpty() ? null : state;
+        });
     }
 
     void pruneInactivePlayers(Predicate<UUID> inactiveOrMissing) {
-        playerData.keySet().removeIf(inactiveOrMissing);
-        connectingPlayers.removeIf(inactiveOrMissing);
-        playerConnectionIssues.keySet().removeIf(inactiveOrMissing);
+        states.keySet().removeIf(inactiveOrMissing);
+    }
+
+    private static final class State {
+        private volatile String serverName;
+        private volatile boolean connecting;
+        private volatile String connectionIssue;
+
+        private State(String serverName) {
+            this.serverName = serverName;
+        }
+
+        private boolean isEmpty() {
+            return serverName == null && !connecting && connectionIssue == null;
+        }
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -11,14 +11,19 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class PlayerManager {
+    private static final long PRUNE_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(1);
+
     public record QueuedPlayer(UUID uuid, String name) {
     }
 
     private final PlayerConnectionState connectionState = new PlayerConnectionState();
     private final ReconnectQueueState reconnectQueueState = new ReconnectQueueState(this::removePlayerState, this::getActivePlayer);
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
+    private final AtomicLong nextPruneAtNanos = new AtomicLong();
     private static String queuePositionMsg;
 
     public PlayerManager() {
@@ -121,20 +126,29 @@ public class PlayerManager {
     public void pruneInactivePlayers() {
         reconnectQueueState.pruneInactivePlayers();
         connectionState.pruneInactivePlayers(this::isInactiveOrMissing);
+        nextPruneAtNanos.set(System.nanoTime() + PRUNE_INTERVAL_NANOS);
+    }
+
+    public void pruneInactivePlayersIfDue() {
+        long now = System.nanoTime();
+        long nextPrune = nextPruneAtNanos.get();
+        if (now < nextPrune || !nextPruneAtNanos.compareAndSet(nextPrune, now + PRUNE_INTERVAL_NANOS)) {
+            return;
+        }
+
+        reconnectQueueState.pruneInactivePlayers();
+        connectionState.pruneInactivePlayers(this::isInactiveOrMissing);
     }
 
     public int getQueuedServerCount() {
-        pruneInactivePlayers();
         return reconnectQueueState.getQueuedServerCount();
     }
 
     public int getQueuedPlayerCount() {
-        pruneInactivePlayers();
         return reconnectQueueState.getQueuedPlayerCount();
     }
 
     public Map<String, Integer> getQueuedServerCounts() {
-        pruneInactivePlayers();
         return reconnectQueueState.getQueuedServerCounts();
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -22,7 +22,7 @@ public class PlayerManager {
     private final PlayerConnectionState connectionState = new PlayerConnectionState();
     private final ReconnectQueueState reconnectQueueState = new ReconnectQueueState(this::removePlayerState, this::getActivePlayer);
     private final AtomicLong nextPruneAtNanos = new AtomicLong();
-    private static String queuePositionMsg;
+    private volatile String queuePositionMsg;
 
     public PlayerManager() {
         reloadMessages();

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -20,7 +20,10 @@ public class PlayerManager {
     }
 
     private final PlayerConnectionState connectionState = new PlayerConnectionState();
-    private final ReconnectQueueState reconnectQueueState = new ReconnectQueueState(this::removePlayerState, this::getActivePlayer);
+    private final ReconnectQueueState reconnectQueueState = new ReconnectQueueState(
+            this::removePlayerStateIfInactive,
+            this::getActivePlayer
+    );
     private final AtomicLong nextPruneAtNanos = new AtomicLong();
     private volatile String queuePositionMsg;
 
@@ -175,6 +178,10 @@ public class PlayerManager {
 
     private void removePlayerState(UUID playerId) {
         connectionState.removePlayerState(playerId);
+    }
+
+    private void removePlayerStateIfInactive(UUID playerId) {
+        connectionState.removePlayerStateIf(playerId, this::isInactiveOrMissing);
     }
 
     private Player getActivePlayer(UUID playerId) {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -104,6 +104,9 @@ public class PlayerManager {
 
     public int getQueuePosition(Player player) {
         RegisteredServer previousServer = getPreviousServer(player);
+        if (previousServer == null) {
+            return -1;
+        }
         return reconnectQueueState.getQueuePosition(player.getUniqueId(), previousServer.getServerInfo().getName());
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -6,7 +6,6 @@ import com.akselglyholt.velocityLimboHandler.misc.Utility;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import dev.dejvokep.boostedyaml.route.Route;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 
 import java.util.List;
 import java.util.Map;
@@ -22,7 +21,6 @@ public class PlayerManager {
 
     private final PlayerConnectionState connectionState = new PlayerConnectionState();
     private final ReconnectQueueState reconnectQueueState = new ReconnectQueueState(this::removePlayerState, this::getActivePlayer);
-    private final MiniMessage miniMessage = MiniMessage.miniMessage();
     private final AtomicLong nextPruneAtNanos = new AtomicLong();
     private static String queuePositionMsg;
 
@@ -64,8 +62,7 @@ public class PlayerManager {
 
         if (VelocityLimboHandler.isQueueEnabled()) {
             reconnectQueueState.enqueue(player, registeredServer);
-            String formattedMessage = MessageFormatter.formatMessage(queuePositionMsg, player);
-            player.sendMessage(miniMessage.deserialize(formattedMessage));
+            player.sendMessage(MessageFormatter.formatComponent(queuePositionMsg, player));
         }
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -138,6 +138,14 @@ public class PlayerManager {
         return reconnectQueueState.getQueuedServerCounts();
     }
 
+    public List<String> getQueuedServerNames() {
+        return reconnectQueueState.getQueuedServerNames();
+    }
+
+    public int getQueueSize(String serverName) {
+        return reconnectQueueState.getQueueSize(serverName);
+    }
+
     public List<QueuedPlayer> getQueueForServer(String serverName) {
         return reconnectQueueState.getQueueForServer(serverName);
     }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManager.java
@@ -40,7 +40,7 @@ public class PlayerManager {
     public void addPlayer(Player player, RegisteredServer registeredServer) {
         UUID playerId = player.getUniqueId();
         if (connectionState.isRegistered(playerId)) {
-            Utility.logDebug(String.format(
+            Utility.logDebug(() -> String.format(
                     "Skipping addPlayer for %s — already registered for '%s'",
                     player.getUsername(),
                     connectionState.getRegisteredServer(playerId).orElse("unknown")));
@@ -48,14 +48,14 @@ public class PlayerManager {
         }
 
         if (isAuthBlocked(player)) {
-            Utility.logDebug(String.format("Skipping addPlayer for %s — auth blocked", player.getUsername()));
+            Utility.logDebug(() -> String.format("Skipping addPlayer for %s — auth blocked", player.getUsername()));
             return;
         }
 
         String serverName = registeredServer.getServerInfo().getName();
         connectionState.registerPlayer(playerId, serverName);
 
-        VelocityLimboHandler.getLogger().info(String.format(
+        Utility.logDebug(() -> String.format(
                 "%s joined limbo — queued for %s", player.getUsername(), serverName));
 
         Utility.sendWelcomeMessage(player, null);

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
@@ -5,6 +5,7 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 
 import java.util.LinkedHashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -18,6 +19,7 @@ final class ReconnectQueueState {
     private static final long POSITION_CACHE_TTL_NANOS = TimeUnit.SECONDS.toNanos(1);
 
     private final Map<String, ServerQueue> reconnectQueues = new ConcurrentHashMap<>();
+    private final Map<UUID, String> queueByPlayer = new ConcurrentHashMap<>();
     private final Map<String, QueuePositionCacheEntry> queuePositionCache = new ConcurrentHashMap<>();
     private final Consumer<UUID> staleEntryRemover;
     private final Function<UUID, Player> activePlayerResolver;
@@ -31,16 +33,25 @@ final class ReconnectQueueState {
         String serverName = server.getServerInfo().getName();
         UUID playerId = player.getUniqueId();
 
-        ServerQueue serverQueue = getOrCreateServerQueue(serverName);
-        serverQueue.enqueue(playerId, getTier(player, serverName));
-        invalidatePositionCache(serverName);
+        queueByPlayer.compute(playerId, (ignored, previousServerName) -> {
+            if (previousServerName != null && !previousServerName.equals(serverName)) {
+                removeFromServerQueue(previousServerName, playerId);
+            }
+
+            reconnectQueues.compute(serverName, (ignoredServerName, serverQueue) -> {
+                ServerQueue targetQueue = serverQueue != null ? serverQueue : new ServerQueue();
+                targetQueue.enqueue(playerId, getTier(player, serverName));
+                return targetQueue;
+            });
+            invalidatePositionCache(serverName);
+            return serverName;
+        });
     }
 
     void removePlayer(UUID playerId) {
-        reconnectQueues.forEach((serverName, serverQueue) -> {
-            if (serverQueue.remove(playerId)) {
-                invalidatePositionCache(serverName);
-            }
+        queueByPlayer.computeIfPresent(playerId, (ignored, serverName) -> {
+            removeFromServerQueue(serverName, playerId);
+            return null;
         });
     }
 
@@ -52,10 +63,14 @@ final class ReconnectQueueState {
         }
 
         long beforeVersion = serverQueue.version();
-        Player nextPlayer = serverQueue.getNextActivePlayer(this::getActivePlayer, staleEntryRemover);
+        Player nextPlayer = serverQueue.getNextActivePlayer(
+                this::getActivePlayer,
+                playerId -> removeStaleOwnership(serverName, playerId)
+        );
         if (serverQueue.version() != beforeVersion) {
             invalidatePositionCache(serverName);
         }
+        removeServerQueueIfEmpty(serverName, serverQueue);
 
         return nextPlayer;
     }
@@ -75,9 +90,13 @@ final class ReconnectQueueState {
 
     void pruneInactivePlayers() {
         reconnectQueues.forEach((serverName, serverQueue) -> {
-            if (serverQueue.pruneInactivePlayers(this::getActivePlayer, staleEntryRemover)) {
+            if (serverQueue.pruneInactivePlayers(
+                    this::getActivePlayer,
+                    playerId -> removeStaleOwnership(serverName, playerId)
+            )) {
                 invalidatePositionCache(serverName);
             }
+            removeServerQueueIfEmpty(serverName, serverQueue);
         });
     }
 
@@ -105,6 +124,21 @@ final class ReconnectQueueState {
         return queueCounts;
     }
 
+    List<String> getQueuedServerNames() {
+        List<String> serverNames = new ArrayList<>();
+        reconnectQueues.forEach((serverName, serverQueue) -> {
+            if (!serverQueue.isEmpty()) {
+                serverNames.add(serverName);
+            }
+        });
+        return serverNames;
+    }
+
+    int getQueueSize(String serverName) {
+        ServerQueue serverQueue = getServerQueue(serverName);
+        return serverQueue == null ? 0 : serverQueue.size();
+    }
+
     List<PlayerManager.QueuedPlayer> getQueueForServer(String serverName) {
         ServerQueue serverQueue = getServerQueue(serverName);
         if (serverQueue == null || serverQueue.isEmpty()) {
@@ -112,10 +146,14 @@ final class ReconnectQueueState {
         }
 
         long beforeVersion = serverQueue.version();
-        List<PlayerManager.QueuedPlayer> queuedPlayers = serverQueue.getActiveQueuedPlayers(this::getActivePlayer, staleEntryRemover);
+        List<PlayerManager.QueuedPlayer> queuedPlayers = serverQueue.getActiveQueuedPlayers(
+                this::getActivePlayer,
+                playerId -> removeStaleOwnership(serverName, playerId)
+        );
         if (serverQueue.version() != beforeVersion) {
             invalidatePositionCache(serverName);
         }
+        removeServerQueueIfEmpty(serverName, serverQueue);
 
         return queuedPlayers;
     }
@@ -130,7 +168,7 @@ final class ReconnectQueueState {
         long beforeVersion = serverQueue.version();
         Player maintenanceAllowed = serverQueue.findFirstActiveMatching(
                 this::getActivePlayer,
-                staleEntryRemover,
+                playerId -> removeStaleOwnership(serverName, playerId),
                 player -> player.hasPermission("maintenance.admin")
                         || player.hasPermission("maintenance.bypass")
                         || player.hasPermission("maintenance.singleserver.bypass." + serverName)
@@ -163,35 +201,64 @@ final class ReconnectQueueState {
         return reconnectQueues.get(serverName);
     }
 
-    private ServerQueue getOrCreateServerQueue(String serverName) {
-        return reconnectQueues.computeIfAbsent(serverName, key -> new ServerQueue());
-    }
-
     private Player getActivePlayer(UUID playerId) {
         return activePlayerResolver.apply(playerId);
     }
 
     private Map<UUID, Integer> getOrBuildQueuePositions(String serverName, ServerQueue serverQueue) {
-        QueuePositionCacheEntry cached = queuePositionCache.get(serverName);
-        long now = System.nanoTime();
-        long version = serverQueue.version();
+        while (true) {
+            QueuePositionCacheEntry cached = queuePositionCache.get(serverName);
+            long now = System.nanoTime();
+            long version = serverQueue.version();
 
-        if (cached != null && cached.version() == version && now < cached.expiresAtNanos()) {
-            return cached.positions();
+            if (cached != null && cached.version() == version && now < cached.expiresAtNanos()) {
+                return cached.positions();
+            }
+
+            ServerQueue.PositionSnapshot snapshot = serverQueue.buildPositionSnapshot(
+                    this::getActivePlayer,
+                    playerId -> removeStaleOwnership(serverName, playerId)
+            );
+            QueuePositionCacheEntry fresh = new QueuePositionCacheEntry(
+                    snapshot.version(),
+                    now + POSITION_CACHE_TTL_NANOS,
+                    snapshot.positions()
+            );
+            queuePositionCache.put(serverName, fresh);
+
+            if (serverQueue.version() == snapshot.version()) {
+                return snapshot.positions();
+            }
+
+            queuePositionCache.remove(serverName, fresh);
         }
-
-        Map<UUID, Integer> positions = serverQueue.buildPositionMap(this::getActivePlayer, staleEntryRemover);
-        QueuePositionCacheEntry fresh = new QueuePositionCacheEntry(
-                serverQueue.version(),
-                now + POSITION_CACHE_TTL_NANOS,
-                positions
-        );
-        queuePositionCache.put(serverName, fresh);
-        return positions;
     }
 
     private void invalidatePositionCache(String serverName) {
         queuePositionCache.remove(serverName);
+    }
+
+    private void removeFromServerQueue(String serverName, UUID playerId) {
+        reconnectQueues.computeIfPresent(serverName, (ignored, serverQueue) -> {
+            if (serverQueue.remove(playerId)) {
+                invalidatePositionCache(serverName);
+            }
+            return serverQueue.isEmpty() ? null : serverQueue;
+        });
+    }
+
+    private void removeStaleOwnership(String serverName, UUID playerId) {
+        queueByPlayer.remove(playerId, serverName);
+        staleEntryRemover.accept(playerId);
+    }
+
+    private void removeServerQueueIfEmpty(String serverName, ServerQueue expectedQueue) {
+        reconnectQueues.computeIfPresent(serverName, (ignored, currentQueue) ->
+                currentQueue == expectedQueue && currentQueue.isEmpty() ? null : currentQueue
+        );
+        if (!reconnectQueues.containsKey(serverName)) {
+            invalidatePositionCache(serverName);
+        }
     }
 
     private record QueuePositionCacheEntry(long version, long expiresAtNanos, Map<UUID, Integer> positions) {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 final class ReconnectQueueState {
-    private static final long POSITION_CACHE_TTL_NANOS = TimeUnit.SECONDS.toNanos(1);
+    private static final long POSITION_CACHE_TTL_NANOS = TimeUnit.MINUTES.toNanos(1);
     private static final long MAINTENANCE_CANDIDATE_TTL_NANOS = TimeUnit.SECONDS.toNanos(5);
 
     private final Map<String, ServerQueue> reconnectQueues = new ConcurrentHashMap<>();

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
@@ -17,10 +17,12 @@ import java.util.function.Function;
 
 final class ReconnectQueueState {
     private static final long POSITION_CACHE_TTL_NANOS = TimeUnit.SECONDS.toNanos(1);
+    private static final long MAINTENANCE_CANDIDATE_TTL_NANOS = TimeUnit.SECONDS.toNanos(5);
 
     private final Map<String, ServerQueue> reconnectQueues = new ConcurrentHashMap<>();
     private final Map<UUID, String> queueByPlayer = new ConcurrentHashMap<>();
     private final Map<String, QueuePositionCacheEntry> queuePositionCache = new ConcurrentHashMap<>();
+    private final Map<String, MaintenanceCandidateCacheEntry> maintenanceCandidateCache = new ConcurrentHashMap<>();
     private final Consumer<UUID> staleEntryRemover;
     private final Function<UUID, Player> activePlayerResolver;
 
@@ -165,20 +167,45 @@ final class ReconnectQueueState {
             return null;
         }
 
-        long beforeVersion = serverQueue.version();
-        Player maintenanceAllowed = serverQueue.findFirstActiveMatching(
+        long now = System.nanoTime();
+        long version = serverQueue.version();
+        MaintenanceCandidateCacheEntry cached = maintenanceCandidateCache.get(serverName);
+        if (cached != null && cached.version() == version && now < cached.expiresAtNanos()) {
+            if (cached.playerId() == null) {
+                return null;
+            }
+            Player cachedPlayer = getActivePlayer(cached.playerId());
+            if (cachedPlayer != null && isMaintenanceAllowed(cachedPlayer, serverName)) {
+                return cachedPlayer;
+            }
+            maintenanceCandidateCache.remove(serverName, cached);
+        }
+
+        long beforeVersion = version;
+        ServerQueue.MatchSnapshot match = serverQueue.findFirstActiveMatching(
                 this::getActivePlayer,
                 playerId -> removeStaleOwnership(serverName, playerId),
-                player -> player.hasPermission("maintenance.admin")
-                        || player.hasPermission("maintenance.bypass")
-                        || player.hasPermission("maintenance.singleserver.bypass." + serverName)
-                        || Utility.playerMaintenanceWhitelisted(player)
+                player -> isMaintenanceAllowed(player, serverName)
         );
         if (serverQueue.version() != beforeVersion) {
             invalidatePositionCache(serverName);
         }
 
+        Player maintenanceAllowed = match.player();
+        maintenanceCandidateCache.put(serverName, new MaintenanceCandidateCacheEntry(
+                match.version(),
+                now + MAINTENANCE_CANDIDATE_TTL_NANOS,
+                maintenanceAllowed == null ? null : maintenanceAllowed.getUniqueId()
+        ));
+
         return maintenanceAllowed;
+    }
+
+    private boolean isMaintenanceAllowed(Player player, String serverName) {
+        return player.hasPermission("maintenance.admin")
+                || player.hasPermission("maintenance.bypass")
+                || player.hasPermission("maintenance.singleserver.bypass." + serverName)
+                || Utility.playerMaintenanceWhitelisted(player);
     }
 
     private QueueTier getTier(Player player, String serverName) {
@@ -242,6 +269,7 @@ final class ReconnectQueueState {
         reconnectQueues.computeIfPresent(serverName, (ignored, serverQueue) -> {
             if (serverQueue.remove(playerId)) {
                 invalidatePositionCache(serverName);
+                maintenanceCandidateCache.remove(serverName);
             }
             return serverQueue.isEmpty() ? null : serverQueue;
         });
@@ -262,5 +290,8 @@ final class ReconnectQueueState {
     }
 
     private record QueuePositionCacheEntry(long version, long expiresAtNanos, Map<UUID, Integer> positions) {
+    }
+
+    private record MaintenanceCandidateCacheEntry(long version, long expiresAtNanos, UUID playerId) {
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
@@ -276,8 +276,9 @@ final class ReconnectQueueState {
     }
 
     private void removeStaleOwnership(String serverName, UUID playerId) {
-        queueByPlayer.remove(playerId, serverName);
-        staleEntryRemover.accept(playerId);
+        if (queueByPlayer.remove(playerId, serverName)) {
+            staleEntryRemover.accept(playerId);
+        }
     }
 
     private void removeServerQueueIfEmpty(String serverName, ServerQueue expectedQueue) {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
@@ -70,7 +70,7 @@ final class ReconnectQueueState {
                 playerId -> removeStaleOwnership(serverName, playerId)
         );
         if (serverQueue.version() != beforeVersion) {
-            invalidatePositionCache(serverName);
+            invalidateQueueCaches(serverName);
         }
         removeServerQueueIfEmpty(serverName, serverQueue);
 
@@ -87,7 +87,9 @@ final class ReconnectQueueState {
             return -1;
         }
 
-        return getOrBuildQueuePositions(serverName, serverQueue).getOrDefault(targetId, -1);
+        int position = getOrBuildQueuePositions(serverName, serverQueue).getOrDefault(targetId, -1);
+        removeServerQueueIfEmpty(serverName, serverQueue);
+        return position;
     }
 
     void pruneInactivePlayers() {
@@ -96,7 +98,7 @@ final class ReconnectQueueState {
                     this::getActivePlayer,
                     playerId -> removeStaleOwnership(serverName, playerId)
             )) {
-                invalidatePositionCache(serverName);
+                invalidateQueueCaches(serverName);
             }
             removeServerQueueIfEmpty(serverName, serverQueue);
         });
@@ -153,7 +155,7 @@ final class ReconnectQueueState {
                 playerId -> removeStaleOwnership(serverName, playerId)
         );
         if (serverQueue.version() != beforeVersion) {
-            invalidatePositionCache(serverName);
+            invalidateQueueCaches(serverName);
         }
         removeServerQueueIfEmpty(serverName, serverQueue);
 
@@ -188,7 +190,7 @@ final class ReconnectQueueState {
                 player -> isMaintenanceAllowed(player, serverName)
         );
         if (serverQueue.version() != beforeVersion) {
-            invalidatePositionCache(serverName);
+            invalidateQueueCaches(serverName);
         }
 
         Player maintenanceAllowed = match.player();
@@ -197,6 +199,7 @@ final class ReconnectQueueState {
                 now + MAINTENANCE_CANDIDATE_TTL_NANOS,
                 maintenanceAllowed == null ? null : maintenanceAllowed.getUniqueId()
         ));
+        removeServerQueueIfEmpty(serverName, serverQueue);
 
         return maintenanceAllowed;
     }
@@ -265,11 +268,15 @@ final class ReconnectQueueState {
         queuePositionCache.remove(serverName);
     }
 
+    private void invalidateQueueCaches(String serverName) {
+        invalidatePositionCache(serverName);
+        maintenanceCandidateCache.remove(serverName);
+    }
+
     private void removeFromServerQueue(String serverName, UUID playerId) {
         reconnectQueues.computeIfPresent(serverName, (ignored, serverQueue) -> {
             if (serverQueue.remove(playerId)) {
-                invalidatePositionCache(serverName);
-                maintenanceCandidateCache.remove(serverName);
+                invalidateQueueCaches(serverName);
             }
             return serverQueue.isEmpty() ? null : serverQueue;
         });
@@ -282,11 +289,11 @@ final class ReconnectQueueState {
     }
 
     private void removeServerQueueIfEmpty(String serverName, ServerQueue expectedQueue) {
-        reconnectQueues.computeIfPresent(serverName, (ignored, currentQueue) ->
+        ServerQueue remainingQueue = reconnectQueues.computeIfPresent(serverName, (ignored, currentQueue) ->
                 currentQueue == expectedQueue && currentQueue.isEmpty() ? null : currentQueue
         );
-        if (!reconnectQueues.containsKey(serverName)) {
-            invalidatePositionCache(serverName);
+        if (remainingQueue == null) {
+            invalidateQueueCaches(serverName);
         }
     }
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueState.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -283,7 +284,16 @@ final class ReconnectQueueState {
     }
 
     private void removeStaleOwnership(String serverName, UUID playerId) {
-        if (queueByPlayer.remove(playerId, serverName)) {
+        AtomicBoolean ownershipRemoved = new AtomicBoolean();
+        queueByPlayer.computeIfPresent(playerId, (ignored, ownedServerName) -> {
+            if (!ownedServerName.equals(serverName) || getActivePlayer(playerId) != null) {
+                return ownedServerName;
+            }
+            ownershipRemoved.set(true);
+            return null;
+        });
+
+        if (ownershipRemoved.get()) {
             staleEntryRemover.accept(playerId);
         }
     }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ServerQueue.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ServerQueue.java
@@ -19,6 +19,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 final class ServerQueue {
+    private static final long VERSION_MISMATCH = -1L;
+
     private final LinkedHashSet<UUID> bypass = new LinkedHashSet<>();
     private final LinkedHashSet<UUID> priority = new LinkedHashSet<>();
     private final LinkedHashSet<UUID> normal = new LinkedHashSet<>();
@@ -31,6 +33,8 @@ final class ServerQueue {
         try {
             QueueTier existingTier = tierByPlayer.get(playerId);
             if (existingTier == tier) {
+                // A repeated enqueue can represent a new player lifecycle for the same UUID.
+                version.incrementAndGet();
                 return;
             }
 
@@ -69,156 +73,101 @@ final class ServerQueue {
         Objects.requireNonNull(activePlayerResolver, "activePlayerResolver");
         Objects.requireNonNull(staleEntryRemover, "staleEntryRemover");
 
-        List<UUID> staleEntries = new ArrayList<>();
-        Player nextPlayer = null;
-        boolean mutated = false;
-
-        lock.lock();
-        try {
-            for (LinkedHashSet<UUID> tierSet : orderedTierSets()) {
-                Iterator<UUID> iterator = tierSet.iterator();
-                while (iterator.hasNext()) {
-                    UUID playerId = iterator.next();
-                    Player player = activePlayerResolver.apply(playerId);
-                    if (player != null) {
-                        nextPlayer = player;
-                        break;
-                    }
-
-                    iterator.remove();
-                    tierByPlayer.remove(playerId);
-                    staleEntries.add(playerId);
-                    mutated = true;
-                }
-
-                if (nextPlayer != null) {
-                    break;
-                }
+        while (true) {
+            HeadSnapshot head = snapshotHead();
+            if (head == null) {
+                return null;
             }
 
-            if (mutated) {
-                version.incrementAndGet();
+            Player player = activePlayerResolver.apply(head.playerId());
+            if (player != null) {
+                if (isCurrentHead(head)) {
+                    return player;
+                }
+                continue;
             }
-        } finally {
-            lock.unlock();
+
+            if (removeCurrentHead(head)) {
+                staleEntryRemover.accept(head.playerId());
+            }
         }
-
-        staleEntries.forEach(staleEntryRemover);
-        return nextPlayer;
     }
 
     boolean pruneInactivePlayers(Function<UUID, Player> activePlayerResolver, Consumer<UUID> staleEntryRemover) {
         Objects.requireNonNull(activePlayerResolver, "activePlayerResolver");
         Objects.requireNonNull(staleEntryRemover, "staleEntryRemover");
 
-        List<UUID> staleEntries = new ArrayList<>();
-        boolean mutated = false;
-
-        lock.lock();
-        try {
-            for (LinkedHashSet<UUID> tierSet : orderedTierSets()) {
-                Iterator<UUID> iterator = tierSet.iterator();
-                while (iterator.hasNext()) {
-                    UUID playerId = iterator.next();
-                    if (activePlayerResolver.apply(playerId) != null) {
-                        continue;
-                    }
-
-                    iterator.remove();
-                    tierByPlayer.remove(playerId);
+        while (true) {
+            QueueSnapshot snapshot = snapshotQueue();
+            List<UUID> staleEntries = new ArrayList<>();
+            for (UUID playerId : snapshot.playerIds()) {
+                if (activePlayerResolver.apply(playerId) == null) {
                     staleEntries.add(playerId);
-                    mutated = true;
                 }
             }
 
-            if (mutated) {
-                version.incrementAndGet();
+            if (removeStaleIfUnchanged(snapshot.version(), staleEntries) == VERSION_MISMATCH) {
+                continue;
             }
-        } finally {
-            lock.unlock();
-        }
 
-        staleEntries.forEach(staleEntryRemover);
-        return mutated;
+            staleEntries.forEach(staleEntryRemover);
+            return !staleEntries.isEmpty();
+        }
     }
 
     PositionSnapshot buildPositionSnapshot(Function<UUID, Player> activePlayerResolver, Consumer<UUID> staleEntryRemover) {
         Objects.requireNonNull(activePlayerResolver, "activePlayerResolver");
         Objects.requireNonNull(staleEntryRemover, "staleEntryRemover");
 
-        List<UUID> staleEntries = new ArrayList<>();
-        Map<UUID, Integer> positions = new HashMap<>();
-        int position = 1;
-        boolean mutated = false;
+        while (true) {
+            QueueSnapshot snapshot = snapshotQueue();
+            List<UUID> staleEntries = new ArrayList<>();
+            Map<UUID, Integer> positions = new HashMap<>();
+            int position = 1;
 
-        long snapshotVersion;
-        lock.lock();
-        try {
-            for (LinkedHashSet<UUID> tierSet : orderedTierSets()) {
-                Iterator<UUID> iterator = tierSet.iterator();
-                while (iterator.hasNext()) {
-                    UUID playerId = iterator.next();
-                    Player player = activePlayerResolver.apply(playerId);
-                    if (player != null) {
-                        positions.putIfAbsent(playerId, position++);
-                        continue;
-                    }
-
-                    iterator.remove();
-                    tierByPlayer.remove(playerId);
+            for (UUID playerId : snapshot.playerIds()) {
+                if (activePlayerResolver.apply(playerId) != null) {
+                    positions.put(playerId, position++);
+                } else {
                     staleEntries.add(playerId);
-                    mutated = true;
                 }
             }
 
-            if (mutated) {
-                version.incrementAndGet();
+            long snapshotVersion = removeStaleIfUnchanged(snapshot.version(), staleEntries);
+            if (snapshotVersion == VERSION_MISMATCH) {
+                continue;
             }
-            snapshotVersion = version.get();
-        } finally {
-            lock.unlock();
-        }
 
-        staleEntries.forEach(staleEntryRemover);
-        return new PositionSnapshot(snapshotVersion, positions);
+            staleEntries.forEach(staleEntryRemover);
+            return new PositionSnapshot(snapshotVersion, positions);
+        }
     }
 
     List<PlayerManager.QueuedPlayer> getActiveQueuedPlayers(Function<UUID, Player> activePlayerResolver, Consumer<UUID> staleEntryRemover) {
         Objects.requireNonNull(activePlayerResolver, "activePlayerResolver");
         Objects.requireNonNull(staleEntryRemover, "staleEntryRemover");
 
-        List<UUID> staleEntries = new ArrayList<>();
-        List<PlayerManager.QueuedPlayer> activePlayers = new ArrayList<>();
-        boolean mutated = false;
+        while (true) {
+            QueueSnapshot snapshot = snapshotQueue();
+            List<UUID> staleEntries = new ArrayList<>();
+            List<PlayerManager.QueuedPlayer> activePlayers = new ArrayList<>(snapshot.playerIds().size());
 
-        lock.lock();
-        try {
-            for (LinkedHashSet<UUID> tierSet : orderedTierSets()) {
-                Iterator<UUID> iterator = tierSet.iterator();
-                while (iterator.hasNext()) {
-                    UUID playerId = iterator.next();
-                    Player player = activePlayerResolver.apply(playerId);
-                    if (player != null) {
-                        activePlayers.add(new PlayerManager.QueuedPlayer(playerId, player.getUsername()));
-                        continue;
-                    }
-
-                    iterator.remove();
-                    tierByPlayer.remove(playerId);
+            for (UUID playerId : snapshot.playerIds()) {
+                Player player = activePlayerResolver.apply(playerId);
+                if (player != null) {
+                    activePlayers.add(new PlayerManager.QueuedPlayer(playerId, player.getUsername()));
+                } else {
                     staleEntries.add(playerId);
-                    mutated = true;
                 }
             }
 
-            if (mutated) {
-                version.incrementAndGet();
+            if (removeStaleIfUnchanged(snapshot.version(), staleEntries) == VERSION_MISMATCH) {
+                continue;
             }
-        } finally {
-            lock.unlock();
-        }
 
-        staleEntries.forEach(staleEntryRemover);
-        return activePlayers;
+            staleEntries.forEach(staleEntryRemover);
+            return activePlayers;
+        }
     }
 
     Player findFirstActiveMatching(Function<UUID, Player> activePlayerResolver,
@@ -228,45 +177,28 @@ final class ServerQueue {
         Objects.requireNonNull(staleEntryRemover, "staleEntryRemover");
         Objects.requireNonNull(matcher, "matcher");
 
-        List<UUID> staleEntries = new ArrayList<>();
-        Player matchedPlayer = null;
-        boolean mutated = false;
+        while (true) {
+            QueueSnapshot snapshot = snapshotQueue();
+            List<UUID> staleEntries = new ArrayList<>();
+            Player matchedPlayer = null;
 
-        lock.lock();
-        try {
-            for (LinkedHashSet<UUID> tierSet : orderedTierSets()) {
-                Iterator<UUID> iterator = tierSet.iterator();
-                while (iterator.hasNext()) {
-                    UUID playerId = iterator.next();
-                    Player player = activePlayerResolver.apply(playerId);
-                    if (player == null) {
-                        iterator.remove();
-                        tierByPlayer.remove(playerId);
-                        staleEntries.add(playerId);
-                        mutated = true;
-                        continue;
-                    }
-
-                    if (matcher.test(player)) {
-                        matchedPlayer = player;
-                        break;
-                    }
-                }
-
-                if (matchedPlayer != null) {
+            for (UUID playerId : snapshot.playerIds()) {
+                Player player = activePlayerResolver.apply(playerId);
+                if (player == null) {
+                    staleEntries.add(playerId);
+                } else if (matcher.test(player)) {
+                    matchedPlayer = player;
                     break;
                 }
             }
 
-            if (mutated) {
-                version.incrementAndGet();
+            if (removeStaleIfUnchanged(snapshot.version(), staleEntries) == VERSION_MISMATCH) {
+                continue;
             }
-        } finally {
-            lock.unlock();
-        }
 
-        staleEntries.forEach(staleEntryRemover);
-        return matchedPlayer;
+            staleEntries.forEach(staleEntryRemover);
+            return matchedPlayer;
+        }
     }
 
     List<Queue<UUID>> orderedQueues() {
@@ -300,6 +232,90 @@ final class ServerQueue {
         return version.get();
     }
 
+    private HeadSnapshot snapshotHead() {
+        lock.lock();
+        try {
+            for (QueueTier tier : QueueTier.values()) {
+                Iterator<UUID> iterator = tierSet(tier).iterator();
+                if (iterator.hasNext()) {
+                    return new HeadSnapshot(version.get(), iterator.next(), tier);
+                }
+            }
+            return null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean isCurrentHead(HeadSnapshot expected) {
+        lock.lock();
+        try {
+            if (version.get() != expected.version()) {
+                return false;
+            }
+            Iterator<UUID> iterator = tierSet(expected.tier()).iterator();
+            return iterator.hasNext() && iterator.next().equals(expected.playerId());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean removeCurrentHead(HeadSnapshot expected) {
+        lock.lock();
+        try {
+            if (version.get() != expected.version()) {
+                return false;
+            }
+            Iterator<UUID> iterator = tierSet(expected.tier()).iterator();
+            if (!iterator.hasNext() || !iterator.next().equals(expected.playerId())) {
+                return false;
+            }
+            iterator.remove();
+            tierByPlayer.remove(expected.playerId());
+            version.incrementAndGet();
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private QueueSnapshot snapshotQueue() {
+        lock.lock();
+        try {
+            List<UUID> playerIds = new ArrayList<>(tierByPlayer.size());
+            playerIds.addAll(bypass);
+            playerIds.addAll(priority);
+            playerIds.addAll(normal);
+            return new QueueSnapshot(version.get(), playerIds);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private long removeStaleIfUnchanged(long expectedVersion, List<UUID> staleEntries) {
+        lock.lock();
+        try {
+            if (version.get() != expectedVersion) {
+                return VERSION_MISMATCH;
+            }
+
+            boolean mutated = false;
+            for (UUID playerId : staleEntries) {
+                QueueTier tier = tierByPlayer.remove(playerId);
+                if (tier != null) {
+                    tierSet(tier).remove(playerId);
+                    mutated = true;
+                }
+            }
+            if (mutated) {
+                version.incrementAndGet();
+            }
+            return version.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+
     private LinkedHashSet<UUID> tierSet(QueueTier tier) {
         return switch (tier) {
             case BYPASS -> bypass;
@@ -313,6 +329,12 @@ final class ServerQueue {
     }
 
     record PositionSnapshot(long version, Map<UUID, Integer> positions) {
+    }
+
+    private record HeadSnapshot(long version, UUID playerId, QueueTier tier) {
+    }
+
+    private record QueueSnapshot(long version, List<UUID> playerIds) {
     }
 
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ServerQueue.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ServerQueue.java
@@ -142,7 +142,7 @@ final class ServerQueue {
         return mutated;
     }
 
-    Map<UUID, Integer> buildPositionMap(Function<UUID, Player> activePlayerResolver, Consumer<UUID> staleEntryRemover) {
+    PositionSnapshot buildPositionSnapshot(Function<UUID, Player> activePlayerResolver, Consumer<UUID> staleEntryRemover) {
         Objects.requireNonNull(activePlayerResolver, "activePlayerResolver");
         Objects.requireNonNull(staleEntryRemover, "staleEntryRemover");
 
@@ -151,6 +151,7 @@ final class ServerQueue {
         int position = 1;
         boolean mutated = false;
 
+        long snapshotVersion;
         lock.lock();
         try {
             for (LinkedHashSet<UUID> tierSet : orderedTierSets()) {
@@ -173,12 +174,13 @@ final class ServerQueue {
             if (mutated) {
                 version.incrementAndGet();
             }
+            snapshotVersion = version.get();
         } finally {
             lock.unlock();
         }
 
         staleEntries.forEach(staleEntryRemover);
-        return positions;
+        return new PositionSnapshot(snapshotVersion, positions);
     }
 
     List<PlayerManager.QueuedPlayer> getActiveQueuedPlayers(Function<UUID, Player> activePlayerResolver, Consumer<UUID> staleEntryRemover) {
@@ -308,6 +310,9 @@ final class ServerQueue {
 
     private List<LinkedHashSet<UUID>> orderedTierSets() {
         return List.of(bypass, priority, normal);
+    }
+
+    record PositionSnapshot(long version, Map<UUID, Integer> positions) {
     }
 
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ServerQueue.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/storage/ServerQueue.java
@@ -106,7 +106,8 @@ final class ServerQueue {
                 }
             }
 
-            if (removeStaleIfUnchanged(snapshot.version(), staleEntries) == VERSION_MISMATCH) {
+            long snapshotVersion = removeStaleIfUnchanged(snapshot.version(), staleEntries);
+            if (snapshotVersion == VERSION_MISMATCH) {
                 continue;
             }
 
@@ -170,9 +171,9 @@ final class ServerQueue {
         }
     }
 
-    Player findFirstActiveMatching(Function<UUID, Player> activePlayerResolver,
-                                   Consumer<UUID> staleEntryRemover,
-                                   Predicate<Player> matcher) {
+    MatchSnapshot findFirstActiveMatching(Function<UUID, Player> activePlayerResolver,
+                                          Consumer<UUID> staleEntryRemover,
+                                          Predicate<Player> matcher) {
         Objects.requireNonNull(activePlayerResolver, "activePlayerResolver");
         Objects.requireNonNull(staleEntryRemover, "staleEntryRemover");
         Objects.requireNonNull(matcher, "matcher");
@@ -192,12 +193,13 @@ final class ServerQueue {
                 }
             }
 
-            if (removeStaleIfUnchanged(snapshot.version(), staleEntries) == VERSION_MISMATCH) {
+            long snapshotVersion = removeStaleIfUnchanged(snapshot.version(), staleEntries);
+            if (snapshotVersion == VERSION_MISMATCH) {
                 continue;
             }
 
             staleEntries.forEach(staleEntryRemover);
-            return matchedPlayer;
+            return new MatchSnapshot(snapshotVersion, matchedPlayer);
         }
     }
 
@@ -329,6 +331,9 @@ final class ServerQueue {
     }
 
     record PositionSnapshot(long version, Map<UUID, Integer> positions) {
+    }
+
+    record MatchSnapshot(long version, Player player) {
     }
 
     private record HeadSnapshot(long version, UUID playerId, QueueTier tier) {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/QueueNotifierTask.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/QueueNotifierTask.java
@@ -86,6 +86,9 @@ public class QueueNotifierTask implements Runnable {
         }
 
         RegisteredServer previousServer = playerManager.getPreviousServer(player);
+        if (previousServer == null) {
+            return;
+        }
         String serverName = previousServer.getServerInfo().getName();
 
         if (maintenanceCache.computeIfAbsent(serverName, Utility::isServerInMaintenance)) {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/QueueNotifierTask.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/QueueNotifierTask.java
@@ -7,7 +7,6 @@ import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 
 import java.util.ArrayDeque;
 import java.util.HashMap;
@@ -20,7 +19,6 @@ public class QueueNotifierTask implements Runnable {
     private final RegisteredServer limboServer;
     private final PlayerManager playerManager;
     private final ConfigManager configManager;
-    private final MiniMessage miniMessage = MiniMessage.miniMessage();
     private final ArrayDeque<UUID> pendingPlayers = new ArrayDeque<>();
     private long nextCycleAtNanos;
     private long nextDispatchAtNanos;
@@ -80,13 +78,9 @@ public class QueueNotifierTask implements Runnable {
         if (issue != null) {
 
             if ("banned".equals(issue)) {
-                String formatedMsg = MessageFormatter.formatMessage(configManager.getBannedMsg(), player);
-
-                player.sendMessage(miniMessage.deserialize(formatedMsg));
+                player.sendMessage(MessageFormatter.formatComponent(configManager.getBannedMsg(), player));
             } else if ("not_whitelisted".equals(issue)) {
-                String formatedMsg = MessageFormatter.formatMessage(configManager.getWhitelistedMsg(), player);
-
-                player.sendMessage(miniMessage.deserialize(formatedMsg));
+                player.sendMessage(MessageFormatter.formatComponent(configManager.getWhitelistedMsg(), player));
             }
             return;
         }
@@ -95,9 +89,9 @@ public class QueueNotifierTask implements Runnable {
         String serverName = previousServer.getServerInfo().getName();
 
         if (maintenanceCache.computeIfAbsent(serverName, Utility::isServerInMaintenance)) {
-            String formatedMsg = MessageFormatter.formatMessage(configManager.getMaintenanceModeMsg(), player);
-
-            player.sendMessage(miniMessage.deserialize(formatedMsg));
+            player.sendMessage(MessageFormatter.formatComponent(
+                    configManager.getMaintenanceModeMsg(), player, null, previousServer
+            ));
             return;
         }
 
@@ -105,8 +99,8 @@ public class QueueNotifierTask implements Runnable {
 
         int position = playerManager.getQueuePosition(player);
         if (position == -1) return;
-        String formatedQueuePositionMsg = MessageFormatter.formatMessage(configManager.getQueuePositionMsg(), player);
-
-        player.sendMessage(miniMessage.deserialize(formatedQueuePositionMsg));
+        player.sendMessage(MessageFormatter.formatComponent(
+                configManager.getQueuePositionMsg(), player, position, previousServer
+        ));
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/QueueNotifierTask.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/QueueNotifierTask.java
@@ -5,16 +5,30 @@ import com.akselglyholt.velocityLimboHandler.misc.MessageFormatter;
 import com.akselglyholt.velocityLimboHandler.misc.Utility;
 import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
 public class QueueNotifierTask implements Runnable {
+    private final ProxyServer proxyServer;
     private final RegisteredServer limboServer;
     private final PlayerManager playerManager;
     private final ConfigManager configManager;
     private final MiniMessage miniMessage = MiniMessage.miniMessage();
+    private final ArrayDeque<UUID> pendingPlayers = new ArrayDeque<>();
+    private long nextCycleAtNanos;
+    private long nextDispatchAtNanos;
+    private long dispatchSpacingNanos;
 
-    public QueueNotifierTask(RegisteredServer limboServer, PlayerManager playerManager, ConfigManager configManager) {
+    public QueueNotifierTask(ProxyServer proxyServer, RegisteredServer limboServer, PlayerManager playerManager,
+                             ConfigManager configManager) {
+        this.proxyServer = proxyServer;
         this.limboServer = limboServer;
         this.playerManager = playerManager;
         this.configManager = configManager;
@@ -22,40 +36,77 @@ public class QueueNotifierTask implements Runnable {
 
     @Override
     public void run() {
-        for (Player player : limboServer.getPlayersConnected()) {
-            // Always show connection issue messages regardless of queue status
-            if (playerManager.hasConnectionIssue(player)) {
-                String issue = playerManager.getConnectionIssue(player);
-
-                if ("banned".equals(issue)) {
-                    String formatedMsg = MessageFormatter.formatMessage(configManager.getBannedMsg(), player);
-
-                    player.sendMessage(miniMessage.deserialize(formatedMsg));
-                } else if ("not_whitelisted".equals(issue)) {
-                    String formatedMsg = MessageFormatter.formatMessage(configManager.getWhitelistedMsg(), player);
-
-                    player.sendMessage(miniMessage.deserialize(formatedMsg));
-                }
-                continue;
+        long now = System.nanoTime();
+        if (pendingPlayers.isEmpty()) {
+            if (now < nextCycleAtNanos) {
+                return;
             }
+            startNotificationCycle(now);
+        }
 
-            RegisteredServer previousServer = playerManager.getPreviousServer(player);
+        Map<String, Boolean> maintenanceCache = new HashMap<>();
+        int batchLimit = Math.max(1, configManager.getQueueNotifyBatchSize());
+        int processed = 0;
+        while (!pendingPlayers.isEmpty() && now >= nextDispatchAtNanos && processed < batchLimit) {
+            UUID playerId = pendingPlayers.removeFirst();
+            proxyServer.getPlayer(playerId)
+                    .filter(Player::isActive)
+                    .filter(this::isInLimbo)
+                    .ifPresent(player -> notifyPlayer(player, maintenanceCache));
+            nextDispatchAtNanos += dispatchSpacingNanos;
+            processed++;
+        }
+    }
 
-            if (Utility.isServerInMaintenance(previousServer.getServerInfo().getName())) {
-                String formatedMsg = MessageFormatter.formatMessage(configManager.getMaintenanceModeMsg(), player);
+    private void startNotificationCycle(long now) {
+        for (Player player : limboServer.getPlayersConnected()) {
+            pendingPlayers.addLast(player.getUniqueId());
+        }
+
+        long intervalNanos = TimeUnit.SECONDS.toNanos(Math.max(1, configManager.getQueueNotifyInterval()));
+        nextCycleAtNanos = now + intervalNanos;
+        nextDispatchAtNanos = now;
+        dispatchSpacingNanos = pendingPlayers.isEmpty() ? intervalNanos : Math.max(1L, intervalNanos / pendingPlayers.size());
+    }
+
+    private boolean isInLimbo(Player player) {
+        return player.getCurrentServer()
+                .map(connection -> Utility.doServerNamesMatch(connection.getServer(), limboServer))
+                .orElse(false);
+    }
+
+    private void notifyPlayer(Player player, Map<String, Boolean> maintenanceCache) {
+        String issue = playerManager.getConnectionIssue(player);
+        if (issue != null) {
+
+            if ("banned".equals(issue)) {
+                String formatedMsg = MessageFormatter.formatMessage(configManager.getBannedMsg(), player);
 
                 player.sendMessage(miniMessage.deserialize(formatedMsg));
-                continue;
+            } else if ("not_whitelisted".equals(issue)) {
+                String formatedMsg = MessageFormatter.formatMessage(configManager.getWhitelistedMsg(), player);
+
+                player.sendMessage(miniMessage.deserialize(formatedMsg));
             }
-
-            // Only show queue position if queue is enabled
-            if (!configManager.isQueueEnabled()) continue;
-
-            int position = playerManager.getQueuePosition(player);
-            if (position == -1) continue;
-            String formatedQueuePositionMsg = MessageFormatter.formatMessage(configManager.getQueuePositionMsg(), player);
-
-            player.sendMessage(miniMessage.deserialize(formatedQueuePositionMsg));
+            return;
         }
+
+        RegisteredServer previousServer = playerManager.getPreviousServer(player);
+        String serverName = previousServer.getServerInfo().getName();
+
+        if (maintenanceCache.computeIfAbsent(serverName, Utility::isServerInMaintenance)) {
+            String formatedMsg = MessageFormatter.formatMessage(configManager.getMaintenanceModeMsg(), player);
+
+            player.sendMessage(miniMessage.deserialize(formatedMsg));
+            return;
+        }
+
+        if (!configManager.isQueueEnabled()) return;
+
+        int position = playerManager.getQueuePosition(player);
+        if (position == -1) return;
+        String formatedQueuePositionMsg = MessageFormatter.formatMessage(configManager.getQueuePositionMsg(), player);
+
+        player.sendMessage(miniMessage.deserialize(formatedQueuePositionMsg));
     }
 }

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/ReconnectionTask.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/ReconnectionTask.java
@@ -37,16 +37,21 @@ public class ReconnectionTask implements Runnable {
         Collection<Player> connectedPlayers = limboServer.getPlayersConnected();
         if (connectedPlayers.isEmpty()) return;
 
-        // Prune all in-active members
-        playerManager.pruneInactivePlayers();
+        // Disconnect events normally clean state immediately; this is only a periodic safety net.
+        playerManager.pruneInactivePlayersIfDue();
 
         // Loop through all servers, if queue is enabled
         Map<String, Boolean> maintenanceCache = new HashMap<>();
 
         if (configManager.isQueueEnabled()) {
-            for (RegisteredServer server : proxyServer.getAllServers()) {
+            for (String serverName : playerManager.getQueuedServerNames()) {
+                RegisteredServer server = proxyServer.getServer(serverName).orElse(null);
+                if (server == null) {
+                    continue;
+                }
+
                 // Check if the server is in Maintenance mode
-                if (isServerInMaintenance(server, maintenanceCache)) {
+                if (Utility.isServerInMaintenance(serverName)) {
                     // Is in Maintenance mode, so find first player in queue that can join
                     Player whitelistedPlayer = PlayerManager.findFirstMaintenanceAllowedPlayer(server);
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/ReconnectionTask.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/ReconnectionTask.java
@@ -10,6 +10,9 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 
 import java.util.Collection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,6 +23,7 @@ public class ReconnectionTask implements Runnable {
     private final AuthManager authManager;
     private final ConfigManager configManager;
     private final ReconnectHandler reconnectHandler;
+    private int serverCursor;
 
     public ReconnectionTask(ProxyServer proxyServer, RegisteredServer limboServer, PlayerManager playerManager,
                             AuthManager authManager, ConfigManager configManager, ReconnectHandler reconnectHandler) {
@@ -44,7 +48,17 @@ public class ReconnectionTask implements Runnable {
         Map<String, Boolean> maintenanceCache = new HashMap<>();
 
         if (configManager.isQueueEnabled()) {
-            for (String serverName : playerManager.getQueuedServerNames()) {
+            List<String> queuedServerNames = new ArrayList<>(playerManager.getQueuedServerNames());
+            Collections.sort(queuedServerNames);
+            int serverCount = queuedServerNames.size();
+            if (serverCount == 0) {
+                return;
+            }
+
+            int startIndex = Math.floorMod(serverCursor, serverCount);
+            int batchSize = Math.min(serverCount, Math.max(1, configManager.getReconnectBatchSize()));
+            for (int offset = 0; offset < batchSize; offset++) {
+                String serverName = queuedServerNames.get((startIndex + offset) % serverCount);
                 RegisteredServer server = proxyServer.getServer(serverName).orElse(null);
                 if (server == null) {
                     continue;
@@ -68,6 +82,7 @@ public class ReconnectionTask implements Runnable {
                     reconnectHandler.reconnectPlayer(nextPlayer);
                 }
             }
+            serverCursor = (startIndex + batchSize) % serverCount;
         } else {
             for (Player player : connectedPlayers) {
                 if (!playerManager.hasConnectionIssue(player) && player.isActive()) {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/ReconnectionTask.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/tasks/ReconnectionTask.java
@@ -88,6 +88,9 @@ public class ReconnectionTask implements Runnable {
                 if (!playerManager.hasConnectionIssue(player) && player.isActive()) {
                     // Check if the server is in maintenance mode
                     RegisteredServer previousServer = playerManager.getPreviousServer(player);
+                    if (previousServer == null) {
+                        continue;
+                    }
 
                     if (isServerInMaintenance(previousServer, maintenanceCache)) {
                         // Continue only if player does NOT have a maintenance bypass/whitelist entry

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-file-version: 8
+file-version: 9
 
 # Server configs - These are settings you need to change!
 # The name of the limbo server in your velocity network
@@ -9,10 +9,12 @@ direct-connect-server: lobby # Default "lobby"
 
 # How often the server should check if it can connect
 task-interval: 3000 # The time in milliseconds (Default: 3000)
+reconnect-batch-size: 8 # Maximum backend queues processed per task run (Default: 8)
 
 # How often should the user be notified of their position in the queue
 queue-enabled: true # Should players be reconnected through a queue (Default: true)
 queue-notify-interval: 30 # The time in seconds (Default: 30)
+queue-notify-batch-size: 64 # Maximum due notifications sent per dispatcher tick (Default: 64)
 
 # A list of disabled commands, which will not work inside the Limbo server. Recommended commands are ones that the player can use to transfer server, like /server or /hub
 disabled-commands: ["server", "lobby", "hub"]

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/config/ConfigManagerTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/config/ConfigManagerTest.java
@@ -1,0 +1,33 @@
+package com.akselglyholt.velocityLimboHandler.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ConfigManagerTest {
+
+    @Test
+    void rejectedServerValidationPreservesPublishedSnapshot(@TempDir Path dataDirectory) throws IOException {
+        ConfigManager configManager = new ConfigManager(dataDirectory, Logger.getAnonymousLogger());
+        configManager.load();
+        String publishedLimboName = configManager.getLimboName();
+
+        Files.writeString(dataDirectory.resolve("config.yml"), """
+                file-version: 9
+                limbo-name: missing
+                direct-connect-server: lobby
+                """);
+
+        assertThrows(IOException.class, () -> configManager.load(
+                (limboName, directConnectName) -> !"missing".equals(limboName)
+        ));
+        assertEquals(publishedLimboName, configManager.getLimboName());
+    }
+}

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/managers/BackendHealthTrackerTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/managers/BackendHealthTrackerTest.java
@@ -1,0 +1,67 @@
+package com.akselglyholt.velocityLimboHandler.managers;
+
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+import com.velocitypowered.api.proxy.server.ServerPing;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BackendHealthTrackerTest {
+
+    @Test
+    void probeCoalescesConcurrentRequestsAndReportsFreeSlots() {
+        BackendHealthTracker tracker = new BackendHealthTracker();
+        RegisteredServer server = mockServer("survival");
+        CompletableFuture<ServerPing> pingFuture = new CompletableFuture<>();
+        ServerPing ping = mock(ServerPing.class);
+        ServerPing.Players players = mock(ServerPing.Players.class);
+
+        when(server.ping()).thenReturn(pingFuture);
+        when(ping.getPlayers()).thenReturn(Optional.of(players));
+        when(players.getMax()).thenReturn(100);
+        when(players.getOnline()).thenReturn(73);
+
+        CompletableFuture<BackendHealthTracker.Availability> first = tracker.probe(server);
+        CompletableFuture<BackendHealthTracker.Availability> second = tracker.probe(server);
+
+        assertSame(first, second);
+        pingFuture.complete(ping);
+
+        BackendHealthTracker.Availability availability = first.join();
+        assertTrue(availability.reachable());
+        assertFalse(availability.full());
+        assertEquals(27, availability.reportedFreeSlots());
+        verify(server, times(1)).ping();
+    }
+
+    @Test
+    void probeCachesFailureDuringBackoff() {
+        BackendHealthTracker tracker = new BackendHealthTracker();
+        RegisteredServer server = mockServer("offline");
+        when(server.ping()).thenReturn(CompletableFuture.failedFuture(new IllegalStateException("offline")));
+
+        assertFalse(tracker.probe(server).join().reachable());
+        assertFalse(tracker.probe(server).join().reachable());
+
+        verify(server, times(1)).ping();
+    }
+
+    private RegisteredServer mockServer(String name) {
+        RegisteredServer server = mock(RegisteredServer.class);
+        ServerInfo info = mock(ServerInfo.class);
+        when(server.getServerInfo()).thenReturn(info);
+        when(info.getName()).thenReturn(name);
+        return server;
+    }
+}

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandlerTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandlerTest.java
@@ -108,4 +108,35 @@ class ReconnectHandlerTest {
         verify(healthTracker).invalidate("survival");
         verify(playerManager).setPlayerConnecting(player, false);
     }
+
+    @Test
+    void maintenanceEnabledDuringProbeBlocksConnectionWithoutBypass() {
+        CompletableFuture<BackendHealthTracker.Availability> probe = new CompletableFuture<>();
+        when(healthTracker.probe(server)).thenReturn(probe);
+
+        assertTrue(reconnectHandler.reconnectPlayer(player));
+        utility.when(() -> Utility.isServerInMaintenance("survival")).thenReturn(true);
+        utility.when(() -> Utility.playerMaintenanceWhitelisted(player)).thenReturn(false);
+        probe.complete(new BackendHealthTracker.Availability(true, false, 5));
+
+        verify(player, never()).createConnectionRequest(server);
+        verify(playerManager).setPlayerConnecting(player, false);
+    }
+
+    @Test
+    void maintenanceEnabledDuringProbeAllowsBypassConnection() {
+        CompletableFuture<BackendHealthTracker.Availability> probe = new CompletableFuture<>();
+        CompletableFuture<ConnectionRequestBuilder.Result> connection = new CompletableFuture<>();
+        ConnectionRequestBuilder request = mock(ConnectionRequestBuilder.class);
+        when(healthTracker.probe(server)).thenReturn(probe);
+        when(player.hasPermission("maintenance.bypass")).thenReturn(true);
+        when(player.createConnectionRequest(server)).thenReturn(request);
+        when(request.connect()).thenReturn(connection);
+
+        assertTrue(reconnectHandler.reconnectPlayer(player));
+        utility.when(() -> Utility.isServerInMaintenance("survival")).thenReturn(true);
+        probe.complete(new BackendHealthTracker.Availability(true, false, 5));
+
+        verify(player).createConnectionRequest(server);
+    }
 }

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandlerTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/managers/ReconnectHandlerTest.java
@@ -1,0 +1,111 @@
+package com.akselglyholt.velocityLimboHandler.managers;
+
+import com.akselglyholt.velocityLimboHandler.auth.AuthManager;
+import com.akselglyholt.velocityLimboHandler.config.ConfigManager;
+import com.akselglyholt.velocityLimboHandler.misc.Utility;
+import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
+import com.velocitypowered.api.proxy.ConnectionRequestBuilder;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ReconnectHandlerTest {
+    private PlayerManager playerManager;
+    private BackendHealthTracker healthTracker;
+    private Player player;
+    private RegisteredServer server;
+    private ReconnectHandler reconnectHandler;
+    private MockedStatic<Utility> utility;
+
+    @BeforeEach
+    void setUp() {
+        playerManager = mock(PlayerManager.class);
+        healthTracker = mock(BackendHealthTracker.class);
+        player = mock(Player.class);
+        server = mock(RegisteredServer.class);
+        ServerInfo serverInfo = mock(ServerInfo.class);
+        AuthManager authManager = mock(AuthManager.class);
+        ConfigManager configManager = mock(ConfigManager.class);
+        Logger logger = mock(Logger.class);
+        utility = mockStatic(Utility.class);
+
+        when(player.isActive()).thenReturn(true);
+        when(player.getUsername()).thenReturn("TestPlayer");
+        when(playerManager.getPreviousServer(player)).thenReturn(server);
+        when(server.getServerInfo()).thenReturn(serverInfo);
+        when(serverInfo.getName()).thenReturn("survival");
+
+        reconnectHandler = new ReconnectHandler(
+                playerManager,
+                authManager,
+                configManager,
+                logger,
+                healthTracker
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        utility.close();
+    }
+
+    @Test
+    void exceptionalProbeAlwaysClearsConnectingState() {
+        when(healthTracker.probe(server)).thenReturn(
+                CompletableFuture.failedFuture(new IllegalStateException("probe failed"))
+        );
+
+        assertTrue(reconnectHandler.reconnectPlayer(player));
+
+        verify(playerManager).setPlayerConnecting(player, true);
+        verify(playerManager).setPlayerConnecting(player, false);
+        verify(player, never()).createConnectionRequest(any());
+    }
+
+    @Test
+    void exceptionalConnectionInvalidatesProbeAndClearsConnectingState() {
+        ConnectionRequestBuilder request = mock(ConnectionRequestBuilder.class);
+        CompletableFuture<ConnectionRequestBuilder.Result> connection = new CompletableFuture<>();
+        when(healthTracker.probe(server)).thenReturn(
+                CompletableFuture.completedFuture(new BackendHealthTracker.Availability(true, false, 5))
+        );
+        when(player.createConnectionRequest(server)).thenReturn(request);
+        when(request.connect()).thenReturn(connection);
+
+        assertTrue(reconnectHandler.reconnectPlayer(player));
+        connection.completeExceptionally(new IllegalStateException("connection failed"));
+
+        verify(healthTracker).invalidate("survival");
+        verify(playerManager).setPlayerConnecting(player, false);
+    }
+
+    @Test
+    void synchronousConnectionFailureClearsConnectingState() {
+        ConnectionRequestBuilder request = mock(ConnectionRequestBuilder.class);
+        when(healthTracker.probe(server)).thenReturn(
+                CompletableFuture.completedFuture(new BackendHealthTracker.Availability(true, false, 5))
+        );
+        when(player.createConnectionRequest(server)).thenReturn(request);
+        when(request.connect()).thenThrow(new IllegalStateException("connection failed"));
+
+        assertTrue(reconnectHandler.reconnectPlayer(player));
+
+        verify(healthTracker).invalidate("survival");
+        verify(playerManager).setPlayerConnecting(player, false);
+    }
+}

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/misc/MessageFormatterTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/misc/MessageFormatterTest.java
@@ -5,17 +5,18 @@ import com.akselglyholt.velocityLimboHandler.storage.PlayerManager;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import java.util.List;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -45,11 +46,7 @@ class MessageFormatterTest {
         when(player.getUsername()).thenReturn("Aksel");
         when(playerManager.getQueuePosition(player)).thenReturn(4);
         when(playerManager.getPreviousServer(player)).thenReturn(previousServer);
-        when(playerManager.getQueueForServer("survival")).thenReturn(List.of(
-                new PlayerManager.QueuedPlayer(UUID.randomUUID(), "Alpha"),
-                new PlayerManager.QueuedPlayer(UUID.randomUUID(), "Bravo"),
-                new PlayerManager.QueuedPlayer(UUID.randomUUID(), "Charlie")
-        ));
+        when(playerManager.getQueueSize("survival")).thenReturn(3);
         when(previousServer.getServerInfo()).thenReturn(serverInfo);
         when(serverInfo.getName()).thenReturn("survival");
         when(limboServer.getPlayersConnected()).thenReturn(List.of(player, mock(Player.class)));
@@ -69,7 +66,7 @@ class MessageFormatterTest {
 
         assertEquals("Aksel is #4 of 3 for survival with 2 in limbo", result);
         verify(playerManager).getQueuePosition(player);
-        verify(playerManager).getQueueForServer("survival");
+        verify(playerManager).getQueueSize("survival");
         verify(playerManager, times(1)).getPreviousServer(player);
     }
 
@@ -89,5 +86,19 @@ class MessageFormatterTest {
 
         assertEquals(message, result);
         verifyNoInteractions(playerManager, limboServer, previousServer, serverInfo);
+    }
+
+    @Test
+    void formatComponent_reusesKnownQueueValuesWithoutAnotherPositionLookup() {
+        var component = MessageFormatter.formatComponent(
+                "<yellow>#[queue-position] of [queue-size] for [queued-server]</yellow>",
+                player,
+                7,
+                previousServer
+        );
+
+        assertEquals("#7 of 3 for survival", PlainTextComponentSerializer.plainText().serialize(component));
+        verify(playerManager, never()).getQueuePosition(player);
+        verify(playerManager).getQueueSize("survival");
     }
 }

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/misc/UtilityTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/misc/UtilityTest.java
@@ -1,14 +1,19 @@
 package com.akselglyholt.velocityLimboHandler.misc;
 
 import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
+import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import java.util.Locale;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -82,5 +87,23 @@ class UtilityTest {
 
         assertNull(result);
         verify(logger).severe(contains("is invalid"));
+    }
+
+    @Test
+    void welcomeReasonMatchingDoesNotDependOnSystemLocale() {
+        Locale originalLocale = Locale.getDefault();
+        Player player = mock(Player.class);
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+            Utility.sendWelcomeMessage(player, "CONNECTION-ISSUE");
+
+            ArgumentCaptor<Component> messageCaptor = ArgumentCaptor.forClass(Component.class);
+            verify(player).sendMessage(messageCaptor.capture());
+            String message = PlainTextComponentSerializer.plainText().serialize(messageCaptor.getValue());
+            assertTrue(message.contains("connection issues"));
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
 }

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/AdvancedPlayerStateTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/AdvancedPlayerStateTest.java
@@ -272,6 +272,7 @@ class AdvancedPlayerStateTest {
         Player queuedPlayer = mockPlayer(UUID.randomUUID(), true);
 
         when(configManager.isQueueEnabled()).thenReturn(true);
+        when(configManager.getReconnectBatchSize()).thenReturn(8);
         when(limboServer.getPlayersConnected()).thenReturn(List.of(queuedPlayer));
         when(proxyServer.getAllServers()).thenReturn(List.of(queuedServer, emptyServer));
         playerManager.addPlayer(queuedPlayer, queuedServer);

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/AdvancedPlayerStateTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/AdvancedPlayerStateTest.java
@@ -262,6 +262,37 @@ class AdvancedPlayerStateTest {
         verify(reconnectHandler, never()).reconnectPlayer(eq(null));
     }
 
+    @Test
+    void reconnectionTask_onlyProcessesServersWithQueuedPlayers() {
+        ConfigManager configManager = mock(ConfigManager.class);
+        RegisteredServer limboServer = mockServer("limbo");
+        RegisteredServer queuedServer = mockServer("survival");
+        RegisteredServer emptyServer = mockServer("creative");
+        ReconnectHandler reconnectHandler = mock(ReconnectHandler.class);
+        Player queuedPlayer = mockPlayer(UUID.randomUUID(), true);
+
+        when(configManager.isQueueEnabled()).thenReturn(true);
+        when(limboServer.getPlayersConnected()).thenReturn(List.of(queuedPlayer));
+        when(proxyServer.getAllServers()).thenReturn(List.of(queuedServer, emptyServer));
+        playerManager.addPlayer(queuedPlayer, queuedServer);
+
+        ReconnectionTask task = new ReconnectionTask(
+                proxyServer,
+                limboServer,
+                playerManager,
+                authManager,
+                configManager,
+                reconnectHandler
+        );
+
+        task.run();
+
+        verify(reconnectHandler).reconnectPlayer(queuedPlayer);
+        verify(proxyServer, never()).getAllServers();
+        mockedUtility.verify(() -> Utility.isServerInMaintenance("survival"));
+        mockedUtility.verify(() -> Utility.isServerInMaintenance("creative"), never());
+    }
+
     private RegisteredServer mockServer(String name) {
         RegisteredServer server = mock(RegisteredServer.class);
         ServerInfo info = mock(ServerInfo.class);

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/PlayerConnectionStateTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/PlayerConnectionStateTest.java
@@ -65,4 +65,19 @@ class PlayerConnectionStateTest {
         assertTrue(state.isConnecting(active));
         assertTrue(state.hasConnectionIssue(active));
     }
+
+    @Test
+    void registeringExistingPlayerKeepsTransientState() {
+        PlayerConnectionState state = new PlayerConnectionState();
+        UUID playerId = UUID.randomUUID();
+
+        state.registerPlayer(playerId, "survival");
+        state.setConnecting(playerId, true);
+        state.addConnectionIssue(playerId, "retrying");
+        state.registerPlayer(playerId, "factions");
+
+        assertEquals("factions", state.getRegisteredServer(playerId).orElseThrow());
+        assertTrue(state.isConnecting(playerId));
+        assertEquals("retrying", state.getConnectionIssue(playerId));
+    }
 }

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/PlayerConnectionStateTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/PlayerConnectionStateTest.java
@@ -80,4 +80,15 @@ class PlayerConnectionStateTest {
         assertTrue(state.isConnecting(playerId));
         assertEquals("retrying", state.getConnectionIssue(playerId));
     }
+
+    @Test
+    void conditionalRemovalPreservesAReactivatedPlayer() {
+        PlayerConnectionState state = new PlayerConnectionState();
+        UUID playerId = UUID.randomUUID();
+        state.registerPlayer(playerId, "survival");
+
+        state.removePlayerStateIf(playerId, ignored -> false);
+
+        assertTrue(state.isRegistered(playerId));
+    }
 }

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManagerIntegrationTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManagerIntegrationTest.java
@@ -121,6 +121,7 @@ class PlayerManagerIntegrationTest {
         assertEquals(2, playerManager.getQueuedPlayerCount());
 
         when(proxyServer.getPlayer(stale.getUniqueId())).thenReturn(Optional.empty());
+        playerManager.pruneInactivePlayers();
 
         assertEquals(1, playerManager.getQueuedPlayerCount());
         assertEquals(Map.of("survival", 1), playerManager.getQueuedServerCounts());

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManagerTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/PlayerManagerTest.java
@@ -182,4 +182,13 @@ class PlayerManagerTest {
         assertEquals(1, counts.size());
         assertEquals(2, counts.get("survival"));
     }
+
+    @Test
+    void queuePositionIsUnavailableWhenPlayerStateHasNoTargetServer() {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+        mockedVelocityLimboHandler.when(VelocityLimboHandler::getDirectConnectServer).thenReturn(null);
+
+        assertEquals(-1, playerManager.getQueuePosition(player));
+    }
 }

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueStateTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueStateTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -87,6 +88,29 @@ class ReconnectQueueStateTest {
         assertEquals(-1, state.getQueuePosition(stale.getUniqueId(), "survival"));
         assertEquals(0, state.getQueuedServerCount());
         assertTrue(state.getQueuedServerNames().isEmpty());
+    }
+
+    @Test
+    void staleCleanupPreservesOwnershipWhenPlayerBecomesActiveAgain() {
+        UUID playerId = UUID.randomUUID();
+        Player rejoinedPlayer = mock(Player.class);
+        when(rejoinedPlayer.getUniqueId()).thenReturn(playerId);
+        when(rejoinedPlayer.hasPermission(anyString())).thenReturn(false);
+        AtomicInteger resolutions = new AtomicInteger();
+        List<UUID> removedStale = new ArrayList<>();
+        ReconnectQueueState state = new ReconnectQueueState(
+                removedStale::add,
+                ignored -> resolutions.getAndIncrement() == 0 ? null : rejoinedPlayer
+        );
+        RegisteredServer server = mockServer("survival");
+        state.enqueue(rejoinedPlayer, server);
+
+        assertNull(state.getNextQueuedPlayer(server));
+
+        assertTrue(removedStale.isEmpty());
+        state.enqueue(rejoinedPlayer, server);
+        state.removePlayer(playerId);
+        assertEquals(0, state.getQueuedPlayerCount());
     }
 
     @Test

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueStateTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueStateTest.java
@@ -128,6 +128,28 @@ class ReconnectQueueStateTest {
         assertEquals(Map.of("survival", 1, "factions", 1), state.getQueuedServerCounts());
     }
 
+    @Test
+    void enqueue_movesPlayerBetweenServersAndEvictsEmptyQueue() {
+        Map<UUID, Player> activePlayers = new ConcurrentHashMap<>();
+        ReconnectQueueState state = new ReconnectQueueState(id -> {
+        }, activePlayers::get);
+        RegisteredServer survival = mockServer("survival");
+        RegisteredServer factions = mockServer("factions");
+        Player player = mockPlayer(UUID.randomUUID(), "Mover", activePlayers);
+
+        state.enqueue(player, survival);
+        state.enqueue(player, factions);
+
+        assertEquals(0, state.getQueueSize("survival"));
+        assertEquals(1, state.getQueueSize("factions"));
+        assertEquals(List.of("factions"), state.getQueuedServerNames());
+
+        state.removePlayer(player.getUniqueId());
+
+        assertEquals(0, state.getQueuedServerCount());
+        assertTrue(state.getQueuedServerNames().isEmpty());
+    }
+
     private RegisteredServer mockServer(String name) {
         RegisteredServer server = mock(RegisteredServer.class);
         ServerInfo info = mock(ServerInfo.class);

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueStateTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueStateTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ReconnectQueueStateTest {
@@ -100,6 +102,25 @@ class ReconnectQueueStateTest {
 
             state.removePlayer(whitelisted.getUniqueId());
             assertNull(state.findFirstMaintenanceAllowedPlayer(server));
+        }
+    }
+
+    @Test
+    void findFirstMaintenanceAllowedPlayer_cachesNoMatchByQueueVersion() {
+        Map<UUID, Player> activePlayers = new ConcurrentHashMap<>();
+        ReconnectQueueState state = new ReconnectQueueState(id -> {
+        }, activePlayers::get);
+        RegisteredServer server = mockServer("factions");
+        Player regular = mockPlayer(UUID.randomUUID(), "Regular", activePlayers);
+        state.enqueue(regular, server);
+
+        try (MockedStatic<Utility> mockedUtility = mockStatic(Utility.class)) {
+            mockedUtility.when(() -> Utility.playerMaintenanceWhitelisted(regular)).thenReturn(false);
+
+            assertNull(state.findFirstMaintenanceAllowedPlayer(server));
+            assertNull(state.findFirstMaintenanceAllowedPlayer(server));
+
+            verify(regular, times(1)).hasPermission("maintenance.admin");
         }
     }
 

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueStateTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/storage/ReconnectQueueStateTest.java
@@ -74,6 +74,22 @@ class ReconnectQueueStateTest {
     }
 
     @Test
+    void getQueuePositionEvictsQueueWhenLastEntryIsStale() {
+        Map<UUID, Player> activePlayers = new ConcurrentHashMap<>();
+        ReconnectQueueState state = new ReconnectQueueState(id -> {
+        }, activePlayers::get);
+        RegisteredServer server = mockServer("survival");
+        Player stale = mockPlayer(UUID.randomUUID(), "Stale", activePlayers);
+
+        state.enqueue(stale, server);
+        activePlayers.remove(stale.getUniqueId());
+
+        assertEquals(-1, state.getQueuePosition(stale.getUniqueId(), "survival"));
+        assertEquals(0, state.getQueuedServerCount());
+        assertTrue(state.getQueuedServerNames().isEmpty());
+    }
+
+    @Test
     void findFirstMaintenanceAllowedPlayer_respectsEligibilityChecks() {
         Map<UUID, Player> activePlayers = new ConcurrentHashMap<>();
         ReconnectQueueState state = new ReconnectQueueState(id -> {


### PR DESCRIPTION
## Summary

- replace repeated queue scans with indexed ownership, versioned position snapshots, and immediate cache eviction
- process only active backend queues and distribute reconnect and notification work through configurable batch limits
- coalesce backend pings, cache short-lived availability hints, and apply bounded exponential backoff for offline servers
- move proxy, permission, and integration calls outside queue locks
- cache compiled messages and maintenance reflection lookups while reducing hot-path allocations and logging
- publish configuration reloads atomically and validate server targets before replacing live state
- harden startup, shutdown, stale cleanup, and asynchronous reconnect failure handling

## Backend ping behavior

Free-slot counts are treated only as short-lived scheduling hints. Successful availability is cached briefly, full-server results receive a slightly longer cache, concurrent probes are coalesced, and failed probes back off with jitter. The actual Velocity connection attempt remains authoritative.

## Operator impact

Two configuration controls are added:

- `reconnect-batch-size`: maximum backend queues processed per reconnect task run
- `queue-notify-batch-size`: maximum due notifications sent per dispatcher tick

These smooth CPU work across ticks and allow large networks to tune catch-up speed against peak scheduler load.

## Validation

- `mvn verify`
- 48 tests passed
- shaded plugin JAR built successfully
- committed diff passes `git diff --check`
