### PR TITLE
Add excluded-kick-reasons config option (Unplugged AFK compatibility)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,10 +55,17 @@ reconnect-batch-size: 8              # Maximum backend queues checked per proces
 queue-notify-interval: 30            # How often to tell players their position
 queue-notify-batch-size: 64          # Maximum due notifications sent per dispatcher tick
 disabled-commands: ["server","hub"]  # Commands blocked in limbo
+excluded-kick-reasons: []            # Kick reasons that bypass limbo/reconnect and disconnect the player instead
 ```
 
 The batch limits smooth work across scheduler ticks. Increase them for faster catch-up on very large
 networks, or lower them to cap short CPU bursts on constrained proxies.
+
+`excluded-kick-reasons` is matched case-insensitively against the kick reason a backend server sends.
+Players kicked with a matching reason are disconnected from the proxy normally instead of being caught
+by the limbo/reconnect flow — useful for mods like [Unplugged AFK](https://modrinth.com/mod/unplugged-afk)
+that intentionally disconnect players while keeping their character on the server
+(e.g. `excluded-kick-reasons: ["Your player will be AFK"]`).
 
 👉 Messages can be tweaked in `messages.yml` so your players see exactly what you want.
 

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/VelocityLimboHandler.java
@@ -7,6 +7,7 @@ import com.akselglyholt.velocityLimboHandler.commands.VlhAdminCommand;
 import com.akselglyholt.velocityLimboHandler.config.ConfigManager;
 import com.akselglyholt.velocityLimboHandler.listeners.CommandExecuteEventListener;
 import com.akselglyholt.velocityLimboHandler.listeners.ConnectionListener;
+import com.akselglyholt.velocityLimboHandler.listeners.KickListener;
 import com.akselglyholt.velocityLimboHandler.managers.ReconnectHandler;
 import com.akselglyholt.velocityLimboHandler.misc.InMemoryReconnectBlocker;
 import com.akselglyholt.velocityLimboHandler.misc.ReconnectBlocker;
@@ -128,6 +129,7 @@ public class VelocityLimboHandler {
         reconnectHandler = new ReconnectHandler(playerManager, authManager, configManager, logger);
 
         eventManger.register(this, new ConnectionListener());
+        eventManger.register(this, new KickListener());
         eventManger.register(this, new CommandExecuteEventListener(commandBlocker, configManager));
 
         proxyServer.getCommandManager().register(proxyServer.getCommandManager().metaBuilder("vlh").plugin(this).build(), new VlhAdminCommand());

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/config/ConfigManager.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.logging.Logger;
@@ -98,12 +99,20 @@ public class ConfigManager {
                         1, MAX_NOTIFY_BATCH_SIZE),
                 loadedConfig.getBoolean("queue-enabled", true),
                 List.copyOf(loadedConfig.getStringList("disabled-commands")),
+                normalizeExcludedKickReasons(loadedConfig.getStringList("excluded-kick-reasons")),
                 loadedConfig.getBoolean("connection-warnings", false),
                 loadedConfig.getBoolean("debug", false)
         );
 
         snapshot = freshSnapshot;
         MessageFormatter.clearCache();
+    }
+
+    private List<String> normalizeExcludedKickReasons(List<String> reasons) {
+        return reasons.stream()
+                .map(reason -> reason.trim().toLowerCase(Locale.ROOT))
+                .filter(reason -> !reason.isEmpty())
+                .toList();
     }
 
     private int bounded(String option, int value, int minimum, int maximum) {
@@ -191,6 +200,10 @@ public class ConfigManager {
         return current().disabledCommands();
     }
 
+    public List<String> getExcludedKickReasons() {
+        return current().excludedKickReasons();
+    }
+
     public boolean isConnectionWarningsEnabled() {
         return current().connectionWarnings();
     }
@@ -217,6 +230,7 @@ public class ConfigManager {
             int queueNotifyBatchSize,
             boolean queueEnabled,
             List<String> disabledCommands,
+            List<String> excludedKickReasons,
             boolean connectionWarnings,
             boolean debug
     ) {

--- a/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/KickListener.java
+++ b/src/main/java/com/akselglyholt/velocityLimboHandler/listeners/KickListener.java
@@ -1,0 +1,43 @@
+package com.akselglyholt.velocityLimboHandler.listeners;
+
+import com.akselglyholt.velocityLimboHandler.VelocityLimboHandler;
+import com.akselglyholt.velocityLimboHandler.misc.Utility;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.player.KickedFromServerEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+public class KickListener {
+
+    @Subscribe
+    public void onKickedFromServer(KickedFromServerEvent event) {
+        List<String> excludedReasons = VelocityLimboHandler.getConfigManager().getExcludedKickReasons();
+        if (excludedReasons.isEmpty()) {
+            return;
+        }
+
+        Optional<Component> reasonOptional = event.getServerKickReason();
+        if (reasonOptional.isEmpty()) {
+            return;
+        }
+
+        String plainReason = PlainTextComponentSerializer.plainText().serialize(reasonOptional.get())
+                .toLowerCase(Locale.ROOT);
+
+        for (String excludedReason : excludedReasons) {
+            if (!plainReason.contains(excludedReason)) {
+                continue;
+            }
+
+            Utility.logDebug(() -> String.format(
+                    "%s was kicked from %s with an excluded reason - disconnecting instead of routing to Limbo",
+                    event.getPlayer().getUsername(), event.getServer().getServerInfo().getName()));
+            event.setResult(KickedFromServerEvent.DisconnectPlayer.create(reasonOptional.get()));
+            return;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-file-version: 9
+file-version: 10
 
 # Server configs - These are settings you need to change!
 # The name of the limbo server in your velocity network
@@ -18,6 +18,10 @@ queue-notify-batch-size: 64 # Maximum due notifications sent per dispatcher tick
 
 # A list of disabled commands, which will not work inside the Limbo server. Recommended commands are ones that the player can use to transfer server, like /server or /hub
 disabled-commands: ["server", "lobby", "hub"]
+
+# A list of kick reasons that bypass the Limbo/reconnect flow entirely. If a player is kicked from a backend server with a reason containing any of these entries (case-insensitive), they are disconnected from the proxy instead of being sent to Limbo.
+# Useful for mods that intentionally disconnect players while keeping their character on the server, like Unplugged AFK ("Your player will be AFK")
+excluded-kick-reasons: [] # Default: []
 
 # Debug/information
 connection-warnings: false # Should connection failures/warnings be logged (Default: false)

--- a/src/test/java/com/akselglyholt/velocityLimboHandler/config/ConfigManagerTest.java
+++ b/src/test/java/com/akselglyholt/velocityLimboHandler/config/ConfigManagerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,7 +21,7 @@ class ConfigManagerTest {
         String publishedLimboName = configManager.getLimboName();
 
         Files.writeString(dataDirectory.resolve("config.yml"), """
-                file-version: 9
+                file-version: 10
                 limbo-name: missing
                 direct-connect-server: lobby
                 """);
@@ -29,5 +30,20 @@ class ConfigManagerTest {
                 (limboName, directConnectName) -> !"missing".equals(limboName)
         ));
         assertEquals(publishedLimboName, configManager.getLimboName());
+    }
+
+    @Test
+    void excludedKickReasonsAreNormalizedAndBlankEntriesDropped(@TempDir Path dataDirectory) throws IOException {
+        ConfigManager configManager = new ConfigManager(dataDirectory, Logger.getAnonymousLogger());
+        Files.writeString(dataDirectory.resolve("config.yml"), """
+                file-version: 10
+                limbo-name: limbo
+                direct-connect-server: lobby
+                excluded-kick-reasons: ["Your player will be AFK", "  ", "TIMEOUT"]
+                """);
+
+        configManager.load();
+
+        assertEquals(List.of("your player will be afk", "timeout"), configManager.getExcludedKickReasons());
     }
 }


### PR DESCRIPTION
Closes #84

Hey! As discussed in #84, here's a PR implementing the excluded kick reasons idea.

## What happened
VLH never actually saw kick reasons - there was no `KickedFromServerEvent` handler anywhere, so everyone landing on limbo got queued unconditionally. Unplugged AFK kicks players with `"Your player will be AFK"` while keeping their character alive server-side, so they'd get caught by the limbo flow and reconnected within a second, replacing their AFK bot.

## What this does
- New `KickListener` subscribing to `KickedFromServerEvent`. If the kick reason matches an entry in the new `excluded-kick-reasons` config list, the player is disconnected from the proxy entirely (`DisconnectPlayer.create(reason)`) instead of being routed to limbo - behaving exactly as if VLH wasn't installed.
- Matching is case-insensitive `contains` on the plain-text reason (formatting codes stripped), since Unplugged AFK appends duration info when its `displayDuration` option is enabled and the message is configurable server-side.
- New `excluded-kick-reasons` option in `config.yml` (`file-version` bumped to 10, existing configs auto-migrate). Ships empty, so it's fully opt-in.
- README updated per CONTRIBUTING.md.

## Testing
Tested on my own network (Velocity + backend running Unplugged AFK):
- `/unplug` → player disconnected with the original kick message, no limbo, no reconnect. AFK bot stays alive on the backend.
- Reconnecting later replaces the bot as normal ("Replaced by player").
- Server restart while unplugged → bot respawns at startup as intended, player joins normally afterwards.
- Regular crash/restart protection unaffected (kicks without matching reasons still go through limbo/reconnect).

One note: I left `pom.xml` at 1.8.4 since versioning is your call, but SemVer-wise this would be a minor bump.

Let me know if you'd like anything changed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `excluded-kick-reasons` setting to bypass Limbo/reconnect handling for matching server kick messages.
  * Matching is case-insensitive, with whitespace and blank entries handled automatically.
  * Players with matching reasons are disconnected normally from the proxy.
* **Documentation**
  * Added configuration guidance and an example for intentional AFK-related disconnects.
* **Chores**
  * Updated the configuration version to 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->